### PR TITLE
Navigation changes + news fix

### DIFF
--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -39,26 +39,22 @@ class AuthLoadingScreen extends React.Component {
 const MyDrawerNavigator = createDrawerNavigator({
   Stores: {
     screen: StoresStack,
-    navigationOptions: ({ navigation }) => ({
-      title: 'Stores',
-      drawerLockMode: 'locked-closed'
+    navigationOptions: () => ({
+      title: 'Stores'
     })
   },
   Rewards: {
     screen: RewardsStack,
-    navigationOptions: ({ navigation }) => ({
+    navigationOptions: () => ({
       title: 'Your Profile',
       drawerLockMode: 'locked-closed'
-
     })
   },
   // TODO change the name of Announcements to News (?) across app & Airtable
   Announcements: {
     screen: AnnounceStack,
-    navigationOptions: ({ navigation }) => ({
-      title: 'News',
-      drawerLockMode: 'locked-closed'
-
+    navigationOptions: () => ({
+      title: 'News'
     })
   }
 });

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -41,14 +41,15 @@ const MyDrawerNavigator = createDrawerNavigator({
     screen: StoresStack,
     navigationOptions: ({ navigation }) => ({
       title: 'Stores',
-      edgeWidth: -10
+      drawerLockMode: 'locked-closed'
     })
   },
   Rewards: {
     screen: RewardsStack,
     navigationOptions: ({ navigation }) => ({
       title: 'Your Profile',
-      edgeWidth: -10
+      drawerLockMode: 'locked-closed'
+
     })
   },
   // TODO change the name of Announcements to News (?) across app & Airtable
@@ -56,7 +57,8 @@ const MyDrawerNavigator = createDrawerNavigator({
     screen: AnnounceStack,
     navigationOptions: ({ navigation }) => ({
       title: 'News',
-      edgeWidth: -10
+      drawerLockMode: 'locked-closed'
+
     })
   }
 });

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -40,20 +40,23 @@ const MyDrawerNavigator = createDrawerNavigator({
   Stores: {
     screen: StoresStack,
     navigationOptions: ({ navigation }) => ({
-      title: 'Stores'
+      title: 'Stores',
+      edgeWidth: -10
     })
   },
   Rewards: {
     screen: RewardsStack,
     navigationOptions: ({ navigation }) => ({
-      title: 'Your Profile'
+      title: 'Your Profile',
+      edgeWidth: -10
     })
   },
   // TODO change the name of Announcements to News (?) across app & Airtable
   Announcements: {
     screen: AnnounceStack,
     navigationOptions: ({ navigation }) => ({
-      title: 'News'
+      title: 'News',
+      edgeWidth: -10
     })
   }
 });

--- a/screens/AnnouncementHelper.js
+++ b/screens/AnnouncementHelper.js
@@ -10,7 +10,7 @@ function createAnnouncementData(announcement) {
 }
 
 const getAnnouncements = function async() {
-  return BASE('Announcements')
+  return BASE('News')
     .select({
       view: 'Grid view',
       sort: [{ field: 'Created', direction: 'desc' }]

--- a/screens/AnnouncementScreen.js
+++ b/screens/AnnouncementScreen.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { ScrollView, Text, ViewComponent, TouchableOpacity, Button, View } from 'react-native';
 
 import Announcements from '../components/Announcements';
-import Hamburger from '../components/Hamburger';
 import { TopText } from '../styles/announcements';
 import getAnnouncements from './AnnouncementHelper';
 
@@ -24,6 +23,7 @@ class AnnouncementScreen extends React.Component {
     // const {goBack} = this.props.navigation;
     return (
       <View>
+        {/* TODO @johnathanzhou make this into a new component */}
         <TouchableOpacity
               style={{
                   backgroundColor:'white',

--- a/screens/AnnouncementScreen.js
+++ b/screens/AnnouncementScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, Text, ViewComponent, TouchableOpacity, Button, View } from 'react-native';
+import { ScrollView, Text, TouchableOpacity, Button, View } from 'react-native';
 
 import Announcements from '../components/Announcements';
 import { TopText } from '../styles/announcements';
@@ -20,33 +20,32 @@ class AnnouncementScreen extends React.Component {
   }
 
   render() {
-    // const {goBack} = this.props.navigation;
     return (
       <View>
         {/* TODO @johnathanzhou make this into a new component */}
         <TouchableOpacity
-              style={{
-                  backgroundColor:'white',
-                  width:50,
-                  height:50,
-                  zIndex:100,
-                  position:'absolute', // comment out this line to see the menu toggle
-                  top:50,
-                  left: 15,
-                  borderRadius: 23,
-                  borderColor: '#ffffff',
-                  borderWidth: 4,
-                  shadowOpacity: 0.25,
-                  shadowRadius: 5,
-                  shadowColor: 'black',
-                  shadowOffset: { height: 3, width: 4 },
-              }}>
-              <Button 
-                  color="black" 
-                  title="X"
-                  onPress={() => this.props.navigation.goBack(null)} >
-              </Button>
-          </TouchableOpacity>
+          style={{
+            backgroundColor: 'white',
+            width: 50,
+            height: 50,
+            zIndex: 100,
+            position: 'absolute', // comment out this line to see the menu toggle
+            top: 50,
+            left: 15,
+            borderRadius: 23,
+            borderColor: '#ffffff',
+            borderWidth: 4,
+            shadowOpacity: 0.25,
+            shadowRadius: 5,
+            shadowColor: 'black',
+            shadowOffset: { height: 3, width: 4 }
+          }}>
+          <Button
+            color="black"
+            title="X"
+            onPress={() => this.props.navigation.goBack(null)}
+          />
+        </TouchableOpacity>
         <TopText> News </TopText>
         <ScrollView>
           {this.state.announcements ? (

--- a/screens/AnnouncementScreen.js
+++ b/screens/AnnouncementScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, Text, ViewComponent, TouchableOpacity, Button, View } from 'react-native';
 
 import Announcements from '../components/Announcements';
 import Hamburger from '../components/Hamburger';
@@ -21,9 +21,32 @@ class AnnouncementScreen extends React.Component {
   }
 
   render() {
+    // const {goBack} = this.props.navigation;
     return (
       <View>
-        <Hamburger navigation={this.props.navigation} />
+        <TouchableOpacity
+              style={{
+                  backgroundColor:'white',
+                  width:50,
+                  height:50,
+                  zIndex:100,
+                  position:'absolute', // comment out this line to see the menu toggle
+                  top:50,
+                  left: 15,
+                  borderRadius: 23,
+                  borderColor: '#ffffff',
+                  borderWidth: 4,
+                  shadowOpacity: 0.25,
+                  shadowRadius: 5,
+                  shadowColor: 'black',
+                  shadowOffset: { height: 3, width: 4 },
+              }}>
+              <Button 
+                  color="black" 
+                  title="X"
+                  onPress={() => this.props.navigation.goBack(null)} >
+              </Button>
+          </TouchableOpacity>
         <TopText> News </TopText>
         <ScrollView>
           {this.state.announcements ? (

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -15,6 +15,7 @@ import { TabView, TabBar } from 'react-native-tab-view';
 import RewardsHome from '../../components/RewardsHome';
 import PointsHistory from '../../components/PointsHistory';
 import { getCustomerTransactions, getUser } from './rewardsHelpers';
+import { styles } from '../../styles/rewards'
 
 const routes = [
   { key: 'home', title: 'My Rewards' },
@@ -175,13 +176,16 @@ export default class RewardsScreen extends React.Component {
               onRefresh={this._onRefresh}
             />
           }>
-          <TouchableOpacity
-            style={styles.topTab}
-            onPress={() => this.props.navigation.navigate('Stores')}>
+          <View
+            style={styles.topTab}>
             <View>
+              <TouchableOpacity
+                onPress={() => this.props.navigation.navigate('Stores')}>
+                <Text style={{ color: 'white', fontSize: 25, }}> ⬇ </Text>
+              </TouchableOpacity>
               <Text style={{ color: 'white', fontSize: 30, }}> Healthy Rewards </Text>
             </View>
-          </TouchableOpacity>
+          </View>
           <TabView
             navigationState={this.state}
             renderScene={this.renderScene}
@@ -203,34 +207,4 @@ RewardsScreen.navigationOptions = {
   header: null
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff'
-  },
-  contentContainer: {
-    paddingTop: 30
-  },
-  rewardsTitle: {
-    fontSize: 17,
-    fontWeight: 'bold',
-    color: 'rgba(13, 99, 139, 0.8)',
-    lineHeight: 24,
-    textAlign: 'center'
-  },
-  tabView: {
-    flex: 1,
-    marginTop: 150
-  },
-  topTab: {
-    position: 'absolute',
-    height: 200,
-    top: 0,
-    backgroundColor: '#008550',
-    alignSelf: 'stretch',
-    width,
-    fontSize: 30,
-    alignItems: 'center',
-    justifyContent: 'center'
-  }
-});
+

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -7,7 +7,8 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  View
+  View,
+  TouchableOpacity
 } from 'react-native';
 import { TabView, TabBar } from 'react-native-tab-view';
 
@@ -19,6 +20,10 @@ const routes = [
   { key: 'home', title: 'My Rewards' },
   { key: 'history', title: 'Points History' }
 ];
+
+const {width} = Dimensions.get('window'); // full width
+
+
 export default class RewardsScreen extends React.Component {
   constructor(props) {
     super(props);
@@ -170,7 +175,13 @@ export default class RewardsScreen extends React.Component {
               onRefresh={this._onRefresh}
             />
           }>
-          <Text styles={{ fontSize: 24 }}> Healthy Rewards </Text>
+          <TouchableOpacity
+            style={styles.topTab}
+            onPress={() => this.props.navigation.navigate('Stores')}>
+            <View>
+              <Text style={{ color: 'white', fontSize: 30, }}> Healthy Rewards </Text>
+            </View>
+          </TouchableOpacity>
           <TabView
             navigationState={this.state}
             renderScene={this.renderScene}
@@ -208,6 +219,18 @@ const styles = StyleSheet.create({
     textAlign: 'center'
   },
   tabView: {
-    flex: 1
+    flex: 1,
+    marginTop: 150
+  },
+  topTab: {
+    position: 'absolute',
+    height: 200,
+    top: 0,
+    backgroundColor: '#008550',
+    alignSelf: 'stretch',
+    width,
+    fontSize: 30,
+    alignItems: 'center',
+    justifyContent: 'center'
   }
 });

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -4,8 +4,6 @@ import {
   AsyncStorage,
   Dimensions,
   RefreshControl,
-  ScrollView,
-  StyleSheet,
   Text,
   View,
   TouchableOpacity
@@ -15,15 +13,12 @@ import { TabView, TabBar } from 'react-native-tab-view';
 import RewardsHome from '../../components/RewardsHome';
 import PointsHistory from '../../components/PointsHistory';
 import { getCustomerTransactions, getUser } from './rewardsHelpers';
-import { styles } from '../../styles/rewards'
+import { Container, ScrollViewContainer, RewardsTitle, TopTab, styles } from '../../styles/rewards';
 
 const routes = [
   { key: 'home', title: 'My Rewards' },
   { key: 'history', title: 'Points History' }
 ];
-
-const {width} = Dimensions.get('window'); // full width
-
 
 export default class RewardsScreen extends React.Component {
   constructor(props) {
@@ -145,47 +140,37 @@ export default class RewardsScreen extends React.Component {
   renderTabBar = props => {
     return (
       <TabBar
-        style={{
-          backgroundColor: '#008550',
-          elevation: 0,
-          borderBottomWidth: 0,
-          height: 50
-        }}
-        labelStyle={{
-          color: 'white',
-          textTransform: 'capitalize',
-          fontSize: 16,
-          fontWeight: 'bold'
-        }}
+        style={styles.tabBar}
+        labelStyle={styles.tabBarLabel}
         {...props}
-        indicatorStyle={{ backgroundColor: '#fff', height: 2.5 }}
+        indicatorStyle={styles.tabBarIndicator}
       />
     );
   };
 
   render() {
     return (
-      <View style={styles.container}>
+      <Container>
         {/* Pull-to-refresh functionality */}
-        <ScrollView
-          style={styles.container}
-          contentContainerStyle={styles.contentContainer}
+        <ScrollViewContainer
           refreshControl={
             <RefreshControl
               refreshing={this.state.refreshing}
               onRefresh={this._onRefresh}
             />
           }>
-          <View
-            style={styles.topTab}>
+          <TopTab>
             <View>
               <TouchableOpacity
                 onPress={() => this.props.navigation.navigate('Stores')}>
+                {/* TODO: change this to a proper icon */}
                 <Text style={{ color: 'white', fontSize: 25, }}> ⬇ </Text>
               </TouchableOpacity>
-              <Text style={{ color: 'white', fontSize: 30, }}> Healthy Rewards </Text>
+              <Text style={{ color: 'white', fontSize: 30 }}>
+                Healthy Rewards
+              </Text>
             </View>
-          </View>
+          </TopTab>
           <TabView
             navigationState={this.state}
             renderScene={this.renderScene}
@@ -197,8 +182,8 @@ export default class RewardsScreen extends React.Component {
             }}
             style={styles.tabView}
           />
-        </ScrollView>
-      </View>
+        </ScrollViewContainer>
+      </Container>
     );
   }
 }

--- a/screens/rewards/rewardsHelpers.js
+++ b/screens/rewards/rewardsHelpers.js
@@ -27,7 +27,6 @@ function getUser(id) {
 const getCustomerTransactions = function async(userId) {
   return BASE('Transactions')
     .select({
-      view: 'Transactions',
       filterByFormula: `SEARCH("${userId}", {Customer})`,
       sort: [{ field: 'Date', direction: 'desc' }]
     })

--- a/styles/rewards.js
+++ b/styles/rewards.js
@@ -1,66 +1,63 @@
 import styled from 'styled-components/native';
-import { Dimensions, StyleSheet } from 'react-native';
-
+import { StyleSheet } from 'react-native';
 
 export const Container = styled.View`
-    flex: 1,
-    backgroundColor: '#fff'
+  flex: 1;
+  background-color: #fff;
 `;
-export const ContentContainer = styled.View`
+
+export const ScrollViewContainer = styled.ScrollView.attrs(props => ({
+  contentContainerStyle: {
     paddingTop: 30
+  }
+}))`
+  flex: 1;
+  background-color: #fff;
 `;
+
 export const RewardsTitle = styled.View`
-    fontSize: 17,
-    fontWeight: 'bold',
-    color: 'rgba(13, 99, 139, 0.8)',
-    lineHeight: 24,
-    textAlign: 'center'
+  font-size: 17;
+  font-weight: bold;
+  color: rgba(13, 99, 139, 0.8);
+  line-height: 24;
+  text-align: center;
 `;
-export const TabView = styled.View`
-    flex: 1,
-    marginTop: 150
+export const TopTab = styled.View`
+  position: absolute;
+  height: 200;
+  top: 0;
+  background-color: #008550;
+  align-self: stretch;
+  width: 100%;
+  font-size: 30;
+  align-items: center;
+  justify-content: center;
 `;
-export const topTab = styled.View`
-    position: 'absolute',
-    height: 200,
-    top: 0,
-    backgroundColor: '#008550',
-    alignSelf: 'stretch',
-    width,
-    fontSize: 30,
-    alignItems: 'center',
-    justifyContent: 'center'
+// TODO @anniero98 figure out how to pass styles to third-party components (TabView, TabBar)
+export const StyledTabView = styled.View`
+  flex: 1;
+  margin-top: 150;
 `;
-// TODO @johnathanzhou re-work styles used in rewards screen
 
 export const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: '#fff'
-    },
-    contentContainer: {
-      paddingTop: 30
-    },
-    rewardsTitle: {
-      fontSize: 17,
-      fontWeight: 'bold',
-      color: 'rgba(13, 99, 139, 0.8)',
-      lineHeight: 24,
-      textAlign: 'center'
-    },
-    tabView: {
-      flex: 1,
-      marginTop: 150
-    },
-    topTab: {
-      position: 'absolute',
-      height: 200,
-      top: 0,
-      backgroundColor: '#008550',
-      alignSelf: 'stretch',
-      width: Dimensions.get('window').width,
-      fontSize: 30,
-      alignItems: 'center',
-      justifyContent: 'center'
-    }
-  });
+  tabView: {
+    flex: 1,
+    marginTop: 150
+  },
+  tabBar: {
+    backgroundColor: '#008550',
+    elevation: 0,
+    borderBottomWidth: 0,
+    height: 50
+  },
+  tabBarLabel: {
+    color: 'white',
+    textTransform: 'capitalize',
+    fontSize: 16,
+    fontWeight: 'bold'
+  },
+  tabBarIndicator: {
+    backgroundColor: '#fff',
+    height: 2.5
+  }
+});

--- a/styles/rewards.js
+++ b/styles/rewards.js
@@ -1,0 +1,66 @@
+import styled from 'styled-components/native';
+import { Dimensions, StyleSheet } from 'react-native';
+
+
+export const Container = styled.View`
+    flex: 1,
+    backgroundColor: '#fff'
+`;
+export const ContentContainer = styled.View`
+    paddingTop: 30
+`;
+export const RewardsTitle = styled.View`
+    fontSize: 17,
+    fontWeight: 'bold',
+    color: 'rgba(13, 99, 139, 0.8)',
+    lineHeight: 24,
+    textAlign: 'center'
+`;
+export const TabView = styled.View`
+    flex: 1,
+    marginTop: 150
+`;
+export const topTab = styled.View`
+    position: 'absolute',
+    height: 200,
+    top: 0,
+    backgroundColor: '#008550',
+    alignSelf: 'stretch',
+    width,
+    fontSize: 30,
+    alignItems: 'center',
+    justifyContent: 'center'
+`;
+// TODO @johnathanzhou re-work styles used in rewards screen
+
+export const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: '#fff'
+    },
+    contentContainer: {
+      paddingTop: 30
+    },
+    rewardsTitle: {
+      fontSize: 17,
+      fontWeight: 'bold',
+      color: 'rgba(13, 99, 139, 0.8)',
+      lineHeight: 24,
+      textAlign: 'center'
+    },
+    tabView: {
+      flex: 1,
+      marginTop: 150
+    },
+    topTab: {
+      position: 'absolute',
+      height: 200,
+      top: 0,
+      backgroundColor: '#008550',
+      alignSelf: 'stretch',
+      width: Dimensions.get('window').width,
+      fontSize: 30,
+      alignItems: 'center',
+      justifyContent: 'center'
+    }
+  });


### PR DESCRIPTION
## What's new
* Made it so that you can't swipe to open the drawer
* Added a top tab to the rewards screen that takes you back to the map screen
* Small fix on news screen so that the hamburger icon doesn't show but instead there's an X to close the screen and go to the most recent screen

## Todo
- [x] Drawer still a little buggy in that you can swipe it out, will look into
- [ ] Code tidying -- I created a whole new button for closing inside the news page but I can definitely combine it with the hamburger component and make it more reusable 
- [x] Add an icon that makes it clear that you click in the green area to go back to the stores screen (aka the ↑ that is in the Figma)