### PR TITLE
Filter out Clerk Training store in MapScreen

### DIFF
--- a/lib/mapUtils.js
+++ b/lib/mapUtils.js
@@ -37,7 +37,10 @@ export const getStoreData = function async() {
       .select()
       .all()
       .then(records => {
-        const stores = records.map(record => createStoreData(record));
+        const stores = records
+          // Filter out the Clerk Training store
+          .filter(record => record.id !== 'recq6630DixVw63un')
+          .map(record => createStoreData(record));
         resolve(stores);
       })
       .catch(err => reject(err));


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

- Follow-up from https://github.com/calblueprint/dccentralkitchen-clerks/pull/22, which handles Clerk Training mode for the clerk app. Due to adding the new store in Airtable, needed to adjust the loading products function in `mapUtils` to filter out that store so it wouldn't be shown in the list.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

https://github.com/calblueprint/dccentralkitchen-clerks/pull/22

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

I will probably change this when doing second overhaul of the customer repo (-: but the filtering will still have to happen!

CC: @wangannie @tommypoa 

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
