### PR TITLE
Points History and Rewards tab bar styling + Rewards navigation animations

### DIFF
--- a/components/BaseComponents.js
+++ b/components/BaseComponents.js
@@ -24,6 +24,17 @@ export const NavButton = styled.TouchableOpacity`
   justify-content: center;
 `;
 
+export const CircleIconContainer = styled.View`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  width: 40px;
+  padding: 8px;
+  border-radius: 20px;
+  background-color: ${props => props.color || Colors.lighterGreen};
+`;
+
 export const ButtonContainer = styled.TouchableOpacity``;
 // TODO @tommypoa Replace top / bottom 25%
 export const ButtonLabel = styled(TextButton)`

--- a/components/CircleIcon.js
+++ b/components/CircleIcon.js
@@ -1,0 +1,19 @@
+import { FontAwesome5 } from '@expo/vector-icons';
+import React from 'react';
+import { CircleIconContainer } from './BaseComponents';
+
+export default class CircleIcon extends React.Component {
+  render() {
+    return (
+      <CircleIconContainer color={this.props.circleColor}>
+        <FontAwesome5
+          name={this.props.icon}
+          size={22}
+          solid
+          color={this.props.iconColor}
+          style={{ paddingTop: 1 }}
+        />
+      </CircleIconContainer>
+    );
+  }
+}

--- a/components/resources/ResourceCategoryBar.js
+++ b/components/resources/ResourceCategoryBar.js
@@ -1,21 +1,18 @@
 import React from 'react';
-
-import {
-  CategoryCard,
-  CategoryIcon,
-  HeadingContainer
-} from '../../styled/resources';
+import Colors from '../../assets/Colors';
+import { CategoryCard, HeadingContainer } from '../../styled/resources';
 import { Title } from '../BaseComponents';
-import { FontAwesome5 } from '@expo/vector-icons';
+import CircleIcon from '../CircleIcon';
 
 class ResourceCategoryBar extends React.Component {
   render() {
     return (
       <CategoryCard>
-        <CategoryIcon>
-          <FontAwesome5 name={this.props.icon} size={20} solid color={'#fff'} />
-        </CategoryIcon>
-
+        <CircleIcon
+          icon={this.props.icon}
+          iconColor={Colors.lightest}
+          circleColor={Colors.lighterGreen}
+        />
         <HeadingContainer>
           <Title>{this.props.title}</Title>
         </HeadingContainer>

--- a/components/rewards/PointsHistory.js
+++ b/components/rewards/PointsHistory.js
@@ -19,7 +19,7 @@ function PointsHistory({ transactions, user, updates, navigation }) {
           <Transaction
             key={transaction.id}
             date={transaction.date}
-            points={transaction.points}
+            pointsEarned={transaction.pointsEarned}
             storeName={transaction.storeName}
             subtotal={transaction.subtotal}
             totalSale={transaction.totalSale}

--- a/components/rewards/PointsHistory.js
+++ b/components/rewards/PointsHistory.js
@@ -11,7 +11,7 @@ function PointsHistory({ transactions, user, updates, navigation }) {
   // TODO @kennethlien fix spacing at line 44
   if (transactions) {
     return (
-      <ScrollView style={{ paddingLeft: '5%', paddingRight: '5%' }}>
+      <ScrollView style={{ marginLeft: 16, paddingRight: 16 }}>
         <Overline style={{ marginTop: 24, marginBottom: 12 }}>
           Recent Transactions
         </Overline>

--- a/components/rewards/PointsHistory.js
+++ b/components/rewards/PointsHistory.js
@@ -1,38 +1,31 @@
 import React from 'react';
-import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { Overline } from '../BaseComponents';
 import Transaction from './Transaction';
 /**
  * @prop
  * */
 
-const styles = StyleSheet.create({
-  signOutButton: {
-    fontSize: 20,
-    paddingVertical: 15
-  }
-});
-
 function PointsHistory({ transactions, user, updates, navigation }) {
   // Only display if transactions have mounted
   // TODO @kennethlien fix spacing at line 44
   if (transactions) {
     return (
-      <View>
-        <View>
-          <ScrollView>
-            <Overline style={{ marginTop: 24 }}>Recent Transactions</Overline>
-            {transactions.map(transaction => (
-              <Transaction
-                key={transaction.id}
-                date={transaction.date}
-                points={transaction.points}
-                storeName={transaction.storeName}
-              />
-            ))}
-          </ScrollView>
-        </View>
-      </View>
+      <ScrollView style={{ paddingLeft: '5%', paddingRight: '5%' }}>
+        <Overline style={{ marginTop: 24, marginBottom: 12 }}>
+          Recent Transactions
+        </Overline>
+        {transactions.map(transaction => (
+          <Transaction
+            key={transaction.id}
+            date={transaction.date}
+            points={transaction.points}
+            storeName={transaction.storeName}
+            subtotal={transaction.subtotal}
+            totalSale={transaction.totalSale}
+          />
+        ))}
+      </ScrollView>
     );
   }
   // else return

--- a/components/rewards/RewardsCard.js
+++ b/components/rewards/RewardsCard.js
@@ -1,25 +1,21 @@
 import React from 'react';
-import {
-  RewardsCardContainer,
-  RewardDescriptionContainer,
-  StarIcon
-} from '../../styled/rewards';
-import { Subhead, Caption } from '../BaseComponents';
-import { FontAwesome5 } from '@expo/vector-icons';
 import Colors from '../../assets/Colors';
+import {
+  RewardDescriptionContainer,
+  RewardsCardContainer
+} from '../../styled/rewards';
+import { Caption, Subhead } from '../BaseComponents';
+import CircleIcon from '../CircleIcon';
 
 class RewardsCard extends React.Component {
   render() {
     return (
       <RewardsCardContainer>
-        <StarIcon>
-          <FontAwesome5
-            name="star"
-            solid
-            size={24}
-            color={Colors.primaryGreen}
-          />
-        </StarIcon>
+        <CircleIcon
+          icon="star"
+          iconColor={Colors.primaryGreen}
+          circleColor={Colors.lightest}
+        />
         <RewardDescriptionContainer>
           <Subhead color={Colors.darkerGreen}>$5 Reward</Subhead>
           <Caption color={Colors.darkerGreen}>1000 points</Caption>

--- a/components/rewards/RewardsHome.js
+++ b/components/rewards/RewardsHome.js
@@ -3,7 +3,7 @@ import { ScrollView } from 'react-native';
 import { ProgressBar } from 'react-native-paper';
 import Colors from '../../assets/Colors';
 import {
-  AvailiableRewardsContainer,
+  AvailableRewardsContainer,
   RewardsProgressContainer
 } from '../../styled/rewards';
 import { Body, Overline, Title } from '../BaseComponents';
@@ -46,14 +46,14 @@ function RewardsHome({ user }) {
           your next $5 reward
         </Body>
         <Overline style={{ marginBottom: 8 }}>
-          AVAILIABLE REWARDS ({Math.floor(parseInt(user.points) / 1000)})
+          AVAILABLE REWARDS ({Math.floor(parseInt(user.points) / 1000)})
         </Overline>
       </RewardsProgressContainer>
-      <AvailiableRewardsContainer>
+      <AvailableRewardsContainer>
         {createList(Math.floor(parseInt(user.points) / 1000)).map(a => (
           <RewardsCard></RewardsCard>
         ))}
-      </AvailiableRewardsContainer>
+      </AvailableRewardsContainer>
     </ScrollView>
   );
 }

--- a/components/rewards/RewardsHome.js
+++ b/components/rewards/RewardsHome.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { View, ScrollView } from 'react-native';
-import { Body, Overline, Title } from '../BaseComponents';
-import {
-  RewardsProgressContainer,
-  AvailiableRewardsContainer
-} from '../../styled/rewards';
+import { ScrollView } from 'react-native';
 import { ProgressBar } from 'react-native-paper';
-import RewardsCard from './RewardsCard';
 import Colors from '../../assets/Colors';
+import {
+  AvailiableRewardsContainer,
+  RewardsProgressContainer
+} from '../../styled/rewards';
+import { Body, Overline, Title } from '../BaseComponents';
+import RewardsCard from './RewardsCard';
 
 /**
  * @prop
@@ -23,35 +23,38 @@ function createList(N) {
 
 function RewardsHome({ user }) {
   return (
-    <View>
-      <ScrollView>
-        <RewardsProgressContainer>
-          <Overline style={{ marginTop: 24, marginBottom: 15 }}>
-            REWARD PROGRESS
-          </Overline>
-          <Title style={{ marginBottom: 2 }}>
-            {parseInt(user.points) % 1000} / 1000
-          </Title>
-          <ProgressBar
-            style={{ height: 20, borderRadius: 20, marginBottom: 15 }}
-            progress={(parseInt(user.points) % 1000) / 1000}
-            color={Colors.primaryGreen}
-          />
-          <Body style={{ marginBottom: 28 }}>
-            Earn {`${1000 - (parseInt(user.points) % 1000)}`} points to unlock
-            your next $5 reward
-          </Body>
-          <Overline style={{ marginBottom: 8 }}>
-            AVAILIABLE REWARDS ({Math.floor(parseInt(user.points) / 1000)})
-          </Overline>
-        </RewardsProgressContainer>
-        <AvailiableRewardsContainer>
-          {createList(Math.floor(parseInt(user.points) / 1000)).map(a => (
-            <RewardsCard></RewardsCard>
-          ))}
-        </AvailiableRewardsContainer>
-      </ScrollView>
-    </View>
+    <ScrollView style={{ marginLeft: 16, paddingRight: 16 }}>
+      <RewardsProgressContainer>
+        <Overline style={{ marginTop: 24, marginBottom: 12 }}>
+          REWARD PROGRESS
+        </Overline>
+        <Title style={{ marginBottom: 2 }}>
+          {parseInt(user.points) % 1000} / 1000
+        </Title>
+        <ProgressBar
+          style={{
+            height: 20,
+            width: '100%',
+            borderRadius: 20,
+            marginBottom: 15
+          }}
+          progress={(parseInt(user.points) % 1000) / 1000}
+          color={Colors.primaryGreen}
+        />
+        <Body style={{ marginBottom: 28 }}>
+          Earn {`${1000 - (parseInt(user.points) % 1000)}`} points to unlock
+          your next $5 reward
+        </Body>
+        <Overline style={{ marginBottom: 8 }}>
+          AVAILIABLE REWARDS ({Math.floor(parseInt(user.points) / 1000)})
+        </Overline>
+      </RewardsProgressContainer>
+      <AvailiableRewardsContainer>
+        {createList(Math.floor(parseInt(user.points) / 1000)).map(a => (
+          <RewardsCard></RewardsCard>
+        ))}
+      </AvailiableRewardsContainer>
+    </ScrollView>
   );
 }
 

--- a/components/rewards/RewardsHome.js
+++ b/components/rewards/RewardsHome.js
@@ -26,7 +26,7 @@ function RewardsHome({ user }) {
     <ScrollView style={{ marginLeft: 16, paddingRight: 16 }}>
       <RewardsProgressContainer>
         <Overline style={{ marginTop: 24, marginBottom: 12 }}>
-          REWARD PROGRESS
+          Reward Progress
         </Overline>
         <Title style={{ marginBottom: 2 }}>
           {parseInt(user.points) % 1000} / 1000
@@ -46,7 +46,7 @@ function RewardsHome({ user }) {
           your next $5 reward
         </Body>
         <Overline style={{ marginBottom: 8 }}>
-          AVAILABLE REWARDS ({Math.floor(parseInt(user.points) / 1000)})
+          Available Rewards ({Math.floor(parseInt(user.points) / 1000)})
         </Overline>
       </RewardsProgressContainer>
       <AvailableRewardsContainer>

--- a/components/rewards/Transaction.js
+++ b/components/rewards/Transaction.js
@@ -25,11 +25,11 @@ function Transaction(props) {
         circleColor={Colors.lightestGreen}
       />
       <ContentContainer>
-        <Caption>
+        <Caption color={Colors.secondaryText}>
           {date.toLocaleDateString('en-US', options)} • {storeName}
         </Caption>
         <Subhead>{pointsEarned} points earned</Subhead>
-        <Caption>
+        <Caption color={Colors.secondaryText}>
           for {displayDollarValue(totalSale ? totalSale : 0)} of healthy
           products
         </Caption>

--- a/components/rewards/Transaction.js
+++ b/components/rewards/Transaction.js
@@ -10,7 +10,7 @@ import CircleIcon from '../CircleIcon';
  * */
 
 function Transaction(props) {
-  const { date, storeName, points, subtotal, totalSale } = props;
+  const { date, storeName, pointsEarned, totalSale } = props;
   const options = {
     weekday: 'short',
     year: 'numeric',
@@ -28,7 +28,7 @@ function Transaction(props) {
         <Caption>
           {date.toLocaleDateString('en-US', options)} • {storeName}
         </Caption>
-        <Subhead>{points} points earned</Subhead>
+        <Subhead>{pointsEarned} points earned</Subhead>
         <Caption>
           for {displayDollarValue(totalSale ? totalSale : 0)} of healthy
           products

--- a/components/rewards/Transaction.js
+++ b/components/rewards/Transaction.js
@@ -1,12 +1,8 @@
-import { FontAwesome5 } from '@expo/vector-icons';
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
-import {
-  Card,
-  ContentContainer,
-  IconContainer
-} from '../../styled/transaction';
-import { Caption, Body } from '../../components/BaseComponents';
+import { Body, Caption } from '../../components/BaseComponents';
+import { Card, ContentContainer } from '../../styled/transaction';
+import CircleIcon from '../CircleIcon';
 
 /**
  * @prop
@@ -17,9 +13,12 @@ function Transaction(props) {
   return (
     <TouchableOpacity>
       <Card>
-        <IconContainer>
-          <FontAwesome5 name="check" size={32} color="green" />
-        </IconContainer>
+        <CircleIcon
+          icon="check"
+          iconColor={Colors.primaryGreen}
+          circleColor={Colors.lightestGreen}
+        />
+
         <ContentContainer>
           <Body>
             {date.toLocaleDateString()} @ {storeName}

--- a/components/rewards/Transaction.js
+++ b/components/rewards/Transaction.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
-import { Body, Caption } from '../../components/BaseComponents';
+import Colors from '../../assets/Colors';
+import { displayDollarValue } from '../../lib/rewardsUtils';
 import { Card, ContentContainer } from '../../styled/transaction';
+import { Caption, Subhead } from '../BaseComponents';
 import CircleIcon from '../CircleIcon';
 
 /**
@@ -9,24 +10,31 @@ import CircleIcon from '../CircleIcon';
  * */
 
 function Transaction(props) {
-  const { date, storeName, points } = props;
+  const { date, storeName, points, subtotal, totalSale } = props;
+  const options = {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  };
   return (
-    <TouchableOpacity>
-      <Card>
-        <CircleIcon
-          icon="check"
-          iconColor={Colors.primaryGreen}
-          circleColor={Colors.lightestGreen}
-        />
-
-        <ContentContainer>
-          <Body>
-            {date.toLocaleDateString()} @ {storeName}
-          </Body>
-          <Caption>{points} Points Redeemed</Caption>
-        </ContentContainer>
-      </Card>
-    </TouchableOpacity>
+    <Card>
+      <CircleIcon
+        icon="check"
+        iconColor={Colors.primaryGreen}
+        circleColor={Colors.lightestGreen}
+      />
+      <ContentContainer>
+        <Caption>
+          {date.toLocaleDateString('en-US', options)} • {storeName}
+        </Caption>
+        <Subhead>{points} points earned</Subhead>
+        <Caption>
+          for {displayDollarValue(totalSale ? totalSale : 0)} of healthy
+          products
+        </Caption>
+      </ContentContainer>
+    </Card>
   );
 }
 

--- a/lib/rewardsUtils.js
+++ b/lib/rewardsUtils.js
@@ -14,8 +14,15 @@ function createTransactionData(record) {
     clerk: transaction.Clerk,
     itemsRedeemed: transaction['Items Redeemed'],
     customerName: transaction['Customer Name'],
-    receipts: transaction.Receipts
+    totalSale: transaction['Total Price']
   };
+}
+export function displayDollarValue(amount, positive = true) {
+  const dollarValue = '$'.concat(amount.toFixed(2).toString());
+  if (positive) {
+    return dollarValue;
+  }
+  return '-'.concat(dollarValue);
 }
 
 // Calls Airtable API to return a promise that

--- a/lib/rewardsUtils.js
+++ b/lib/rewardsUtils.js
@@ -7,7 +7,7 @@ function createTransactionData(record) {
     customer: transaction.Customer,
     // TODO not entirely sure why this was converted to a Date object
     date: new Date(transaction.Date),
-    points: transaction['Points Rewarded'],
+    pointsEarned: transaction['Points Earned'],
     storeName: transaction['Store Name'],
     productsPurchased: transaction['Products Purchased'],
     phone: transaction['Customer Lookup (Phone #)'],

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -9,12 +9,8 @@ import { getUser } from '../lib/rewardsUtils';
 import LoginScreen from '../screens/auth/LoginScreen';
 import SignUpScreen from '../screens/auth/SignUpScreen';
 import WelcomeScreen from '../screens/auth/WelcomeScreen';
-import {
-  ResourcesStack,
-  RewardsStack,
-  RootStack,
-  StoresStack
-} from './StackNavigators';
+import RewardsScreen from '../screens/rewards/RewardsScreen';
+import { ResourcesStack, RootStack, StoresStack } from './StackNavigators';
 
 const AuthStack = createStackNavigator({
   Welcome: WelcomeScreen,
@@ -138,7 +134,7 @@ const MyDrawerNavigator = createDrawerNavigator(
       })
     },
     Rewards: {
-      screen: RewardsStack,
+      screen: props => <RewardsScreen {...props} tab={1} />,
       navigationOptions: () => ({
         title: 'Points History',
         drawerLockMode: 'locked-closed'

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -1,15 +1,20 @@
 import React from 'react';
-import { AsyncStorage, View, TouchableOpacity, Linking } from 'react-native';
+import { AsyncStorage, Linking, TouchableOpacity, View } from 'react-native';
 import { createAppContainer, createSwitchNavigator } from 'react-navigation';
 import { createDrawerNavigator, DrawerItems } from 'react-navigation-drawer';
 import { createStackNavigator } from 'react-navigation-stack';
-import WelcomeScreen from '../screens/auth/WelcomeScreen';
+import Colors from '../assets/Colors';
 import { Title } from '../components/BaseComponents';
+import { getUser } from '../lib/rewardsUtils';
 import LoginScreen from '../screens/auth/LoginScreen';
 import SignUpScreen from '../screens/auth/SignUpScreen';
-import Colors from '../assets/Colors';
-import { getUser } from '../lib/rewardsUtils';
-import { RewardsStack, StoresStack, ResourcesStack } from './StackNavigators';
+import WelcomeScreen from '../screens/auth/WelcomeScreen';
+import {
+  ResourcesStack,
+  RewardsStack,
+  RootStack,
+  StoresStack
+} from './StackNavigators';
 
 const AuthStack = createStackNavigator({
   Welcome: WelcomeScreen,
@@ -119,6 +124,13 @@ export class DrawerContent extends React.Component {
 
 const MyDrawerNavigator = createDrawerNavigator(
   {
+    Root: {
+      screen: RootStack,
+      navigationOptions: () => ({
+        title: 'Root',
+        drawerLabel: () => null
+      })
+    },
     Stores: {
       screen: StoresStack,
       navigationOptions: () => ({
@@ -128,7 +140,7 @@ const MyDrawerNavigator = createDrawerNavigator(
     Rewards: {
       screen: RewardsStack,
       navigationOptions: () => ({
-        title: 'Your Profile',
+        title: 'Points History',
         drawerLockMode: 'locked-closed'
       })
     },

--- a/navigation/StackNavigators.js
+++ b/navigation/StackNavigators.js
@@ -43,18 +43,6 @@ export const RootStack = createStackNavigator(
   }
 );
 
-export const RewardsStack = createStackNavigator(
-  {
-    RewardsHome: RewardsScreen
-  },
-  { mode: 'modal' },
-  config
-);
-
-RewardsStack.navigationOptions = {
-  drawerLabel: 'Points History'
-};
-
 export const NewsStack = createStackNavigator(
   {
     News: NewsScreen,

--- a/navigation/StackNavigators.js
+++ b/navigation/StackNavigators.js
@@ -1,16 +1,13 @@
-import { createStackNavigator } from 'react-navigation-stack';
 import { Platform } from 'react-native';
-
+import { createStackNavigator } from 'react-navigation-stack';
 import MapScreen from '../screens/map/MapScreen';
-import RewardsScreen from '../screens/rewards/RewardsScreen';
-import ReceiptScanner from '../screens/rewards/Camera';
-
 import ProductDetailsScreen from '../screens/map/ProductDetailsScreen';
 import ProductsScreen from '../screens/map/ProductsScreen';
 import StoreListScreen from '../screens/map/StoreListScreen';
-import NewsScreen from '../screens/news/NewsScreen';
 import NewsDetailsScreen from '../screens/news/NewsDetailsScreen';
+import NewsScreen from '../screens/news/NewsScreen';
 import ResourcesScreen from '../screens/resources/ResourcesScreen';
+import RewardsScreen from '../screens/rewards/RewardsScreen';
 
 const config = Platform.select({
   web: { headerMode: 'screen' },
@@ -31,11 +28,26 @@ StoresStack.navigationOptions = {
   drawerLabel: 'Stores'
 };
 
+export const RootStack = createStackNavigator(
+  {
+    MainStack: {
+      screen: StoresStack
+    },
+    RewardsOverlay: {
+      screen: RewardsScreen
+    }
+  },
+  {
+    headerMode: 'none',
+    mode: 'modal'
+  }
+);
+
 export const RewardsStack = createStackNavigator(
   {
-    RewardsHome: RewardsScreen,
-    Camera: ReceiptScanner
+    RewardsHome: RewardsScreen
   },
+  { mode: 'modal' },
   config
 );
 

--- a/screens/map/MapScreen.js
+++ b/screens/map/MapScreen.js
@@ -1,9 +1,9 @@
+import { FontAwesome5 } from '@expo/vector-icons';
 import * as Location from 'expo-location';
 import * as Permissions from 'expo-permissions';
 import convertDistance from 'geolib/es/convertDistance';
 import getDistance from 'geolib/es/getDistance';
 import React from 'react';
-import { FontAwesome5 } from '@expo/vector-icons';
 import {
   Dimensions,
   SafeAreaView,
@@ -13,17 +13,17 @@ import {
 } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import BottomSheet from 'reanimated-bottom-sheet';
+import Colors from '../../assets/Colors';
+import { Subhead } from '../../components/BaseComponents';
 import Hamburger from '../../components/Hamburger';
 import StoreProducts from '../../components/product/StoreProducts';
 import { getProductData, getStoreData } from '../../lib/mapUtils';
-import { Subhead } from '../../components/BaseComponents';
 import {
-  SearchBar,
   BottomSheetContainer,
   BottomSheetHeaderContainer,
-  DragBar
+  DragBar,
+  SearchBar
 } from '../../styled/store';
-import Colors from '../../assets/Colors';
 
 const { width } = Dimensions.get('window'); // full width
 
@@ -256,7 +256,7 @@ export default class MapScreen extends React.Component {
             alignItems: 'center',
             justifyContent: 'center'
           }}
-          onPress={() => this.props.navigation.navigate('Rewards')}>
+          onPress={() => this.props.navigation.navigate('RewardsOverlay')}>
           <View>
             <Subhead color={'#fff'}> Your Rewards </Subhead>
           </View>

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -144,7 +144,7 @@ export default class RewardsScreen extends React.Component {
     return (
       <Container>
         <TopTab>
-          <BackButton onPress={() => this.props.navigation.navigate('Stores')}>
+          <BackButton onPress={() => this.props.navigation.goBack()}>
             <FontAwesome5 name="arrow-down" solid size={24} color="white" />
           </BackButton>
           <BigTitle

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -17,6 +17,7 @@ const routes = [
 export default class RewardsScreen extends React.Component {
   constructor(props) {
     super(props);
+    const tab = this.props.tab || 0;
     this.state = {
       user: {
         id: null,
@@ -26,7 +27,7 @@ export default class RewardsScreen extends React.Component {
       transactions: [],
       refreshing: false,
       updates: false,
-      index: 0,
+      index: tab,
       routes
     };
   }

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -131,6 +131,7 @@ export default class RewardsScreen extends React.Component {
       <TabBar
         style={styles.tabBar}
         labelStyle={styles.tabBarLabel}
+        tabStyle={{ width: 'auto' }}
         {...props}
         indicatorStyle={styles.tabBarIndicator}
       />
@@ -146,10 +147,10 @@ export default class RewardsScreen extends React.Component {
           </BackButton>
           <Title
             style={{
-              marginLeft: '5%',
+              marginLeft: 16,
               color: 'white',
               fontSize: 25,
-              paddingBottom: 40
+              paddingBottom: 50
             }}>
             Healthy Rewards
           </Title>

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { AsyncStorage, Dimensions } from 'react-native';
 import { TabBar, TabView } from 'react-native-tab-view';
 import Colors from '../../assets/Colors';
-import { Title } from '../../components/BaseComponents';
+import { BigTitle } from '../../components/BaseComponents';
 import PointsHistory from '../../components/rewards/PointsHistory';
 import RewardsHome from '../../components/rewards/RewardsHome';
 import { getCustomerTransactions, getUser } from '../../lib/rewardsUtils';
@@ -146,15 +146,14 @@ export default class RewardsScreen extends React.Component {
           <BackButton onPress={() => this.props.navigation.navigate('Stores')}>
             <FontAwesome5 name="arrow-down" solid size={24} color="white" />
           </BackButton>
-          <Title
+          <BigTitle
             style={{
               marginLeft: 16,
               color: Colors.lightest,
-              fontSize: 25,
-              paddingBottom: 50
+              fontSize: 36
             }}>
             Healthy Rewards
-          </Title>
+          </BigTitle>
         </TopTab>
         <TabView
           navigationState={this.state}

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -2,6 +2,7 @@ import { FontAwesome5 } from '@expo/vector-icons';
 import React from 'react';
 import { AsyncStorage, Dimensions } from 'react-native';
 import { TabBar, TabView } from 'react-native-tab-view';
+import Colors from '../../assets/Colors';
 import { Title } from '../../components/BaseComponents';
 import PointsHistory from '../../components/rewards/PointsHistory';
 import RewardsHome from '../../components/rewards/RewardsHome';
@@ -148,7 +149,7 @@ export default class RewardsScreen extends React.Component {
           <Title
             style={{
               marginLeft: 16,
-              color: 'white',
+              color: Colors.lightest,
               fontSize: 25,
               paddingBottom: 50
             }}>

--- a/styled/resources.js
+++ b/styled/resources.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components/native';
-import { Title, Body } from '../components/BaseComponents';
 import Colors from '../assets/Colors';
+import { Body, Title } from '../components/BaseComponents';
 
 export const Card = styled.View`
   border-bottom-width: 1px;
@@ -43,18 +43,6 @@ export const CategoryContainer = styled.View`
   flex-direction: column;
   align-content: center;
   flex: 1;
-`;
-
-export const CategoryIcon = styled.View`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 40px;
-  width: 40px;
-  padding: 8px
-  border-radius: 20px;
-  background-color: ${Colors.lighterGreen};
-  
 `;
 
 export const HeadingContainer = styled.View`

--- a/styled/rewards.js
+++ b/styled/rewards.js
@@ -13,15 +13,6 @@ export const BackButton = styled(NavButton)`
   border-color: ${Colors.primaryGreen};
 `;
 
-export const ScrollViewContainer = styled.ScrollView.attrs(props => ({
-  contentContainerStyle: {
-    paddingTop: 30
-  }
-}))`
-  flex: 1;
-  background-color: #fff;
-`;
-
 export const RewardsCardContainer = styled.View`
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
   border-radius: 9px;
@@ -44,7 +35,7 @@ export const RewardsProgressContainer = styled.View`
   flex-direction: column;
 `;
 
-export const AvailiableRewardsContainer = styled.View`
+export const AvailableRewardsContainer = styled.View`
   margin: 8px 0;
   display: flex
   width: 100%
@@ -53,13 +44,6 @@ export const AvailiableRewardsContainer = styled.View`
   justify-content: flex-start;
 `;
 
-export const RewardsTitle = styled.View`
-  font-size: 17px;
-  font-weight: bold;
-  color: rgba(13, 99, 139, 0.8);
-  line-height: 24px;
-  text-align: center;
-`;
 export const TopTab = styled.View`
   position: absolute;
   height: 190px;
@@ -67,7 +51,6 @@ export const TopTab = styled.View`
   background-color: ${Colors.primaryGreen};
   flex-direction: row;
   width: 100%;
-  font-size: 30px;
   align-items: flex-end;
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
 `;
@@ -76,8 +59,6 @@ export const styles = StyleSheet.create({
   tabView: {
     flex: 1,
     marginTop: 140
-    // paddingLeft: 16,
-    // paddingRight: 16
   },
   tabBar: {
     backgroundColor: Colors.primaryGreen,

--- a/styled/rewards.js
+++ b/styled/rewards.js
@@ -1,7 +1,7 @@
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import styled from 'styled-components/native';
 import Colors from '../assets/Colors';
-import { Caption, NavButton, Subhead } from '../components/BaseComponents';
+import { NavButton } from '../components/BaseComponents';
 
 export const Container = styled.View`
   flex: 1;
@@ -40,22 +40,18 @@ export const RewardDescriptionContainer = styled.View`
 `;
 
 export const RewardsProgressContainer = styled.View`
-  margin: 1% 5%;
+  margin: 8px 0;
   flex-direction: column;
 `;
 
 export const AvailiableRewardsContainer = styled.View`
-  margin: 1% 5%;
+  margin: 8px 0;
   display: flex
   width: 100%
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: flex-start;
 `;
-
-export const ContentText = styled(Subhead)``;
-
-export const ContentText2 = styled(Caption)``;
 
 export const RewardsTitle = styled.View`
   font-size: 17px;
@@ -73,60 +69,33 @@ export const TopTab = styled.View`
   width: 100%;
   font-size: 30px;
   align-items: flex-end;
-`;
-// TODO @anniero98 figure out how to pass styles to third-party components (TabView, TabBar)
-export const StyledTabView = styled.View`
-  flex: 1;
-  margin-top: 150px;
+  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
 `;
 
 export const styles = StyleSheet.create({
   tabView: {
     flex: 1,
-    marginTop: 150
+    marginTop: 140
+    // paddingLeft: 16,
+    // paddingRight: 16
   },
   tabBar: {
-    backgroundColor: '#008550',
+    backgroundColor: Colors.primaryGreen,
     elevation: 0,
     borderBottomWidth: 0,
     height: 50
   },
   tabBarLabel: {
-    color: 'white',
+    color: Colors.lightest,
     textTransform: 'capitalize',
     fontSize: 16,
-    fontWeight: 'bold'
+    fontFamily: 'poppins-medium',
+    paddingLeft: 4,
+    paddingRight: 4
   },
   tabBarIndicator: {
-    backgroundColor: '#fff',
-    height: 2.5
-  },
-  tabBarInfoContainer: {
-    position: 'absolute',
-    bottom: 150,
-    left: 0,
-    right: 0,
-    ...Platform.select({
-      ios: {
-        shadowColor: 'black',
-        shadowOffset: { width: 0, height: 3 },
-        shadowOpacity: 0.1,
-        shadowRadius: 3
-      },
-      android: {
-        elevation: 20
-      }
-    }),
-    alignItems: 'center',
-    backgroundColor: '#fbfbfb',
-    paddingVertical: 20
-  },
-  navigationFilename: {
-    marginTop: 5
-  },
-  getStartedContainer: {
-    alignItems: 'center',
-    marginHorizontal: 50,
-    paddingVertical: 20
+    backgroundColor: Colors.lightest,
+    height: 2,
+    borderRadius: 10
   }
 });

--- a/styled/rewards.js
+++ b/styled/rewards.js
@@ -1,7 +1,7 @@
 import { Platform, StyleSheet } from 'react-native';
 import styled from 'styled-components/native';
-import { Subhead, Caption, NavButton } from '../components/BaseComponents';
 import Colors from '../assets/Colors';
+import { Caption, NavButton, Subhead } from '../components/BaseComponents';
 
 export const Container = styled.View`
   flex: 1;
@@ -32,16 +32,6 @@ export const RewardsCardContainer = styled.View`
   flex-direction: row;
   margin-bottom: 12px;
   background-color: ${Colors.lightestGreen};
-`;
-
-export const StarIcon = styled.View`
-  align-items: center;
-  justify-content: center;
-  height: 40px;
-  width: 40px;
-  border-radius: 20px;
-  background-color: #fff;
-  flex-direction: row;
 `;
 
 export const RewardDescriptionContainer = styled.View`

--- a/styled/rewards.js
+++ b/styled/rewards.js
@@ -45,26 +45,26 @@ export const AvailableRewardsContainer = styled.View`
 `;
 
 export const TopTab = styled.View`
-  position: absolute;
-  height: 190px;
-  top: 0px;
   background-color: ${Colors.primaryGreen};
-  flex-direction: row;
-  width: 100%;
-  align-items: flex-end;
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
+  padding-top: 80px;
+  flex-direction: column;
 `;
+// box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
 
 export const styles = StyleSheet.create({
   tabView: {
-    flex: 1,
-    marginTop: 140
+    flex: 1
   },
   tabBar: {
     backgroundColor: Colors.primaryGreen,
-    elevation: 0,
+    elevation: 2,
     borderBottomWidth: 0,
-    height: 50
+    height: 50,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.2,
+    shadowRadius: 3,
+    justifyContent: 'flex-end'
   },
   tabBarLabel: {
     color: Colors.lightest,

--- a/styled/transaction.js
+++ b/styled/transaction.js
@@ -1,41 +1,23 @@
 import styled from 'styled-components/native';
-import { PoppinsText } from './shared';
+import Colors from '../assets/Colors';
 
 export const Card = styled.View`
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
-  border-style: solid;
-  border-radius: 4px;
   border-width: 1px;
-  border-color: grey;
-  padding: 20px;
-  margin: 2% 5%;
+  border-radius: 4px;
+  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.12);
+  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.14);
+  border-color: ${Colors.lighter};
+  background-color: ${Colors.lightest};
+  margin: 8px 0;
+  padding: 16px 8px;
   flex-direction: row;
-`;
-
-export const IconContainer = styled.View`
-  flex: 1;
-  flex-direction: column;
+  justify-content: space-between;
 `;
 
 export const ContentContainer = styled.View`
-  flex: 4;
   flex-direction: column;
-`;
-
-export const MainText = styled(PoppinsText)`
-  font-style: normal;
-  font-weight: normal;
-  font-size: 16px;
-  line-height: 24px;
-  display: flex;
-  align-items: center;
-  color: rgba(0, 0, 0, 0.8);
-`;
-
-export const Overline = styled(PoppinsText)`
-  font-style: normal;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-  color: #999999;
+  margin-left: 12px;
+  flex: 1;
+  justify-content: flex-start;
 `;


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
Overall, made Rewards and Point History look and feel smoother + various other cleanup.
* Made a new `CircleIcon` component to standardize all the repeated circle icons throughout the app
* Fully styled transaction cards in the points history screen and updated copy to match Figma
* Updated transaction card content:
  * Fixed date formatting
  * Renamed the Airtable call to match the new column name 'Points Earned'
  * Added sale total
* Fixed up styling details in the tab view and cleaned up the Rewards heading bar
* Rearranged drawer navigator so the **Rewards page slides up** as a modal to match the Figma prototypes
* Made 'Points History' in the drawer correctly link to Points History (I think the way I did this was a bit jank so I'd really appreciate some more opinions 😅 )

## Relevant Links


### Online sources

[//]: # "Optional - copy links to any tutorial or documentation that was useful to you when working on this PR"
The reasoning for adding RootStack with Rewards as a modal came from [this](https://egghead.io/lessons/react-native-setup-a-stacknavigator-as-a-modal-in-react-navigation).

https://stackoverflow.com/questions/44248403/passing-props-with-screen-option-in-drawernavigator

Sample modal interaction [Expo Snack ](https://snack.expo.io/?platform=android&name=createStackNavigator%20%7C%20React%20Navigation&dependencies=%40react-native-community%2Fmasked-view%40%5E0.1.7%2C%40react-navigation%2Fnative%40%5E5.1.3%2C%40react-navigation%2Fbottom-tabs%40%5E5.2.4%2C%40react-navigation%2Fdrawer%40%5E5.3.4%2C%40react-navigation%2Fmaterial-bottom-tabs%40%5E5.1.6%2C%40react-navigation%2Fmaterial-top-tabs%40%5E5.1.6%2C%40react-navigation%2Fstack%40%5E5.2.6%2Creact-native-reanimated%40%5E1.7.0%2Creact-native-safe-area-context%40%5E0.7.3%2Creact-native-screens%40%5E2.4.0&sourceUrl=https%3A%2F%2Freactnavigation.org%2Fexamples%2F5.x%2Fstack-modal-presentation.js)

### Related PRs
Continuing to finalize and clean up details from #42 and #30 

## How to review
* Nitpick my code! I wasn't really sure if it was a good idea to put `CircleIconContainer` in `BaseComponents`, but I didnt' want to have to make a another styled just for that... thoughts?
* Look for styling details I might have missed
* Click around and test the navigation interactions to see if anything breaks with the new RootStack

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"
* Make different kinds of points history cards (not just transactions) to match the designs, including reward redeemed, reward unlocked etc.
* Currently, if you switch to the 'My Rewards' tab from opening 'Points History' from the drawer, it will open back to 'My Rewards' if you hit 'Points History' from the drawer again. I decided not to worry about this now based on @anniero98 's recent findings about the updates coming with react-navigation v5.
* Try to figure out how to smooth the transition closing Rewards after it's been opened from the drawer...it would be nice if it slid down but at the moment it just disappears.
* Consider how we may be able to condense the new `CircleIcon` with `NavButton` from #42 
* Cool scrolling animation where 'Healthy Rewards' shrinks and centers upon scrolling :^)
* Look into [Section List](https://reactnative.dev/docs/0.15/sectionlist) for date dividers for points history

## Tests Performed, Edge Cases

[//]: # "Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally"
* Tested on iPhone 11 Pro Max, and iPhone 8 and it the transactions cards, tab bars and heading seem to be responsive

### Screenshots
[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"
* Points History screen
![image](https://user-images.githubusercontent.com/21160510/77495539-205c4b00-6e06-11ea-8b8e-b559d30e3ff5.png)

* Rewards heading with tab bar
![image](https://user-images.githubusercontent.com/21160510/77495562-35d17500-6e06-11ea-9e5a-5725c09cd189.png)

* Transaction cards
![image](https://user-images.githubusercontent.com/21160510/77495574-3ec24680-6e06-11ea-9d19-dabf0352d585.png)

* Full interaction: 
https://www.loom.com/share/945e0d03cab24fcf817938a088cd6069

🥳Rewards finally slides upward!
CC: @anniero98 @wangannie

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
