### PR TITLE
Fix loading drawer bug

### DIFF
--- a/navigation/DrawerContent.js
+++ b/navigation/DrawerContent.js
@@ -18,7 +18,12 @@ class DrawerContent extends React.Component {
   async componentDidMount() {
     try {
       const customerId = await AsyncStorage.getItem('userId');
-      const customer = await getCustomersById(customerId);
+      let customer = null;
+      if (customerId != null) {
+        customer = await getCustomersById(customerId);
+      } else {
+        customer = { name: 'Guest' };
+      }
       this.setState({ customer, isLoading: false });
     } catch (err) {
       console.error('[DrawerContent] Airtable:', err);


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

Fix bug (caused by #48) where loading drawer when logged out would throw Airtable error

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

Caused by swapping Airtable calls in #48, and throwing errors. When logged out, AsyncStorage won't have a `userId` saved, but currently the code will attempt to get a customer back from Airtable using the `null` returned.

## How to review

[//]: # "The order in which to review files and what to expect when testing locally"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases

[//]: # "Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally"

### Screenshots

![image](https://user-images.githubusercontent.com/21094576/78524746-ba6aae80-7789-11ea-8f74-138d4960498e.png)
 ^ should no longer appear

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @wangannie

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
