### PR TITLE
Filters for Store List

### DIFF
--- a/.env.generator.example
+++ b/.env.generator.example
@@ -1,5 +1,6 @@
 ## Named to conform to airtable-schema-generator's expectations
 REACT_APP_AIRTABLE_API_KEY='YOUR-API-KEY-HERE'
+AIRTABLE_BASE_ID='DEV_OR_PROD'
 
 ## Needed for airtable-schema-generator if using auto mode
 AIRTABLE_EMAIL='YOUR-EMAIL-HERE'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
     'no-this-before-super': 'warn',
     'no-undef': 'warn',
     'no-unreachable': 'warn',
-    'no-unused-vars': 'warn',
+    'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
     'constructor-super': 'warn',
     'valid-typeof': 'warn',
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,5 +50,6 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     'react/forbid-prop-types': ['on', { forbid: ['any'] }],
     'react/jsx-closing-bracket-location': 'off',
+    'react/jsx-wrap-multilines': 'off',
   },
 };

--- a/components/store/StoreCard.js
+++ b/components/store/StoreCard.js
@@ -5,9 +5,7 @@ import React from 'react';
 import { Dimensions, TouchableOpacity } from 'react-native';
 import { Chip } from 'react-native-paper';
 import Colors from '../../constants/Colors';
-import { formatPhoneNumber } from '../../lib/authUtils';
 import {
-  computeStoreOpen,
   getMaxWidth,
   openDirections,
   writeToClipboard,
@@ -32,7 +30,7 @@ import { Caption, Title } from '../BaseComponents';
 export default function StoreCard({ store, storeList, seeDistance }) {
   const {
     storeName,
-    storeHours,
+    storeOpenStatus,
     phoneNumber,
     address,
     distance,
@@ -45,8 +43,6 @@ export default function StoreCard({ store, storeList, seeDistance }) {
   } = store;
 
   const navigation = useNavigation();
-
-  const storeOpenStatus = computeStoreOpen(storeHours);
 
   return (
     <TouchableOpacity
@@ -186,9 +182,7 @@ export default function StoreCard({ store, storeList, seeDistance }) {
             color={Colors.secondaryText}
           />
           <StoreDetailText>
-            {phoneNumber
-              ? formatPhoneNumber(phoneNumber)
-              : 'Phone number unavailable'}
+            {phoneNumber || 'Phone number unavailable'}
           </StoreDetailText>
         </InLineContainer>
         <InLineContainer style={{ alignItems: 'center' }}>
@@ -214,13 +208,11 @@ export default function StoreCard({ store, storeList, seeDistance }) {
 
 StoreCard.propTypes = {
   store: PropTypes.object,
-  callBack: PropTypes.func,
   storeList: PropTypes.bool,
   seeDistance: PropTypes.bool.isRequired,
 };
 
 StoreCard.defaultProps = {
   store: null,
-  callBack: null,
   storeList: false,
 };

--- a/components/store/StoreCard.js
+++ b/components/store/StoreCard.js
@@ -100,8 +100,8 @@ export default function StoreCard({ store, storeList, seeDistance }) {
                     style={{ marginTop: -1 }}
                   />
                 )}
-                textStyle={styles.chipText}
-                style={styles.chip}>
+                textStyle={styles.tagChipText}
+                style={styles.tagChip}>
                 <Caption color={Colors.darkerGreen}>EBT</Caption>
               </Chip>
             )}
@@ -116,8 +116,8 @@ export default function StoreCard({ store, storeList, seeDistance }) {
                     style={{ marginTop: -1 }}
                   />
                 )}
-                textStyle={styles.chipText}
-                style={styles.chip}>
+                textStyle={styles.tagChipText}
+                style={styles.tagChip}>
                 <Caption color={Colors.darkerGreen}>WIC</Caption>
               </Chip>
             )}
@@ -131,8 +131,8 @@ export default function StoreCard({ store, storeList, seeDistance }) {
                     style={{ marginTop: -1 }}
                   />
                 )}
-                textStyle={styles.chipText}
-                style={styles.chip}>
+                textStyle={styles.tagChipText}
+                style={styles.tagChip}>
                 <Caption color={Colors.darkerGreen}>SNAP Match</Caption>
               </Chip>
             )}
@@ -147,8 +147,8 @@ export default function StoreCard({ store, storeList, seeDistance }) {
                     style={{ marginTop: -1 }}
                   />
                 )}
-                textStyle={styles.chipText}
-                style={styles.chip}>
+                textStyle={styles.tagChipText}
+                style={styles.tagChip}>
                 <Caption color={Colors.darkerGreen}>Healthy Rewards</Caption>
               </Chip>
             )}

--- a/lib/mapUtils.js
+++ b/lib/mapUtils.js
@@ -204,16 +204,20 @@ function computeStoreOpen(hours) {
     return 'Store hours unavailable';
   }
 }
-// Adds fields 'distance', 'storeOpenStatus', 'productInStock' to stores
-// Transforms other necessary fields
+// Adds fields 'distance', 'storeOpenStatus' to store
+// Adds necessary fields for filtering
 function updateStoreData(record) {
   return {
     ...record,
     distance: null,
     phoneNumber:
       'phoneNumber' in record ? formatPhoneNumber(record.phoneNumber) : '',
+    // Pre-processing to add these properties to make filtering easier
     storeOpenStatus: computeStoreOpen(record.storeHours),
     productsInStock: 'productIds' in record,
+    snapOrEbtAccepted: 'snapOrEbtAccepted' in record,
+    wic: 'wic' in record,
+    rewardsAccepted: 'rewardsAccepted' in record,
   };
 }
 
@@ -230,7 +234,6 @@ export async function getStoreData() {
   const stores = records
     .filter(record => record.id !== RecordIds.clerkTrainingStoreId)
     .map(updateStoreData);
-  console.log(stores);
   return stores;
 }
 

--- a/lib/mapUtils.js
+++ b/lib/mapUtils.js
@@ -8,46 +8,7 @@ import {
 } from '../constants/DaysOfTheWeek';
 import RecordIds from '../constants/RecordIds';
 import { getAllStores, getProductsByIds } from './airtable/request';
-
-// Adds field 'distance' to stores
-function updateStoreData(record) {
-  return { ...record, distance: null };
-}
-
-// Adds field 'imageUrl' to products
-function updateProductData(record) {
-  return { ...record, imageUrl: record.image ? record.image[0].url : null };
-}
-
-// Gets all records in Airtable from the Stores table
-// Returns a promise that resolves to an array of Store objects
-export async function getStoreData() {
-  const records = await getAllStores();
-  // Filter out the Clerk Training store
-  const stores = records
-    .filter(record => record.id !== RecordIds.clerkTrainingStoreId)
-    .map(updateStoreData);
-  return stores;
-}
-
-// Gets all products for this store using linked records in Store table from Products table
-export async function getProductData(store) {
-  // Gracefully handle stores without products
-  if (!('productIds' in store)) {
-    return [];
-  }
-  const records = await getProductsByIds(store.productIds);
-  const storeProducts = records.map(updateProductData);
-  return storeProducts;
-}
-
-// Necessary to take into account different screen sizes
-// 32px: Width of left and right margins
-// 12px: Extra space for padding between items
-// 30px: Width of info button + padding
-export const getMaxWidth = function sync(screenWidth) {
-  return screenWidth - 32 - 12 - 30;
-};
+import { formatPhoneNumber } from './authUtils';
 
 // Takes in a string input hours and outputs a dictionary mapping
 // each day of the week to the store hours for that day.
@@ -70,7 +31,7 @@ export function constructHoursDict(hours) {
   if (hoursStrSplit.length === 2 && hoursStrSplit.includes('Daily')) {
     const time = hoursStrSplit[0];
 
-    daysOfTheWeekFull.map((day, _) => {
+    daysOfTheWeekFull.forEach((day, _) => {
       hoursPerDayDict[day] = time;
     });
   }
@@ -81,7 +42,7 @@ export function constructHoursDict(hours) {
     // e.g. timeAndDayPairs = ['9am-8pm Tu-Sat', '9am-7pm Sun', ...]
     const timeAndDayPairs = formattedHours.split(', ');
 
-    timeAndDayPairs.map((timeAndDayPair, _) => {
+    timeAndDayPairs.forEach((timeAndDayPair, _) => {
       // e.g. timeAndDaySplit = ['9am-8pm', 'Tu-Sat']
       const timeAndDaySplit = timeAndDayPair.split(' ');
       // e.g. 9am-8pm
@@ -110,7 +71,7 @@ export function constructHoursDict(hours) {
           numDaysInInterval = indexLastDay - indexFirstDay + 8;
         }
 
-        [...Array(numDaysInInterval).keys()].map((i, _) => {
+        [...Array(numDaysInInterval).keys()].forEach((i, _unused) => {
           const dayIndex = (indexFirstDay + i) % 7;
           hoursPerDayDict[daysOfTheWeekFull[dayIndex]] = time;
         });
@@ -124,7 +85,7 @@ export function constructHoursDict(hours) {
     });
   }
   // If the hours for that day are not available, set it as 'Closed'.
-  daysOfTheWeekFull.map(day => {
+  daysOfTheWeekFull.forEach(day => {
     if (!Object.keys(hoursPerDayDict).includes(day)) {
       hoursPerDayDict[day] = 'Closed';
     }
@@ -142,7 +103,7 @@ function computeNextOpenDay(todaysDayIndex, hoursPerDayDict) {
   let nextDayStoreHours = hoursPerDayDict[nextDay];
   // Loop until next open day is found.
   // Case: All days are closed. We should limit to 7 loops.
-  for (let i = 0; i < 7; i++) {
+  for (let i = 0; i < 7; i += 1) {
     if (nextDayStoreHours !== 'Closed') {
       const nextDayHoursSplit = nextDayStoreHours.split('-');
       const nextOpeningTime = nextDayHoursSplit[0]; // e.g. "8:30am"
@@ -164,7 +125,7 @@ function computeNextOpenDay(todaysDayIndex, hoursPerDayDict) {
 
 // Takes in a store's hours and returns a string indicating whether the
 // store is currently open or when it will next open.
-export function computeStoreOpen(hours) {
+function computeStoreOpen(hours) {
   try {
     if (hours === 'Open 24/7' || hours === 'Store hours unavailable') {
       return hours;
@@ -243,6 +204,54 @@ export function computeStoreOpen(hours) {
     return 'Store hours unavailable';
   }
 }
+// Adds fields 'distance', 'storeOpenStatus', 'productInStock' to stores
+// Transforms other necessary fields
+function updateStoreData(record) {
+  return {
+    ...record,
+    distance: null,
+    phoneNumber:
+      'phoneNumber' in record ? formatPhoneNumber(record.phoneNumber) : '',
+    storeOpenStatus: computeStoreOpen(record.storeHours),
+    productsInStock: 'productIds' in record,
+  };
+}
+
+// Adds field 'imageUrl' to products
+function updateProductData(record) {
+  return { ...record, imageUrl: record.image ? record.image[0].url : null };
+}
+
+// Gets all records in Airtable from the Stores table
+// Returns a promise that resolves to an array of Store objects
+export async function getStoreData() {
+  const records = await getAllStores();
+  // Filter out the Clerk Training store
+  const stores = records
+    .filter(record => record.id !== RecordIds.clerkTrainingStoreId)
+    .map(updateStoreData);
+  console.log(stores);
+  return stores;
+}
+
+// Gets all products for this store using linked records in Store table from Products table
+export async function getProductData(store) {
+  // Gracefully handle stores without products
+  if (!('productIds' in store)) {
+    return [];
+  }
+  const records = await getProductsByIds(store.productIds);
+  const storeProducts = records.map(updateProductData);
+  return storeProducts;
+}
+
+// Necessary to take into account different screen sizes
+// 32px: Width of left and right margins
+// 12px: Extra space for padding between items
+// 30px: Width of info button + padding
+export const getMaxWidth = function sync(screenWidth) {
+  return screenWidth - 32 - 12 - 30;
+};
 
 export function writeToClipboard(string) {
   Clipboard.setString(string);

--- a/screens/auth/SignUpScreen.js
+++ b/screens/auth/SignUpScreen.js
@@ -139,8 +139,8 @@ export default class SignUpScreen extends React.Component {
 
       Analytics.setUserId(customerId);
       Analytics.setUserProperties({
-        name: name,
-        phoneNumber: phoneNumber,
+        name,
+        phoneNumber,
       });
       Sentry.configureScope(scope => {
         scope.setUser({

--- a/screens/map/StoreDetailsScreen.js
+++ b/screens/map/StoreDetailsScreen.js
@@ -14,7 +14,6 @@ import {
 } from '../../components/BaseComponents';
 import StoreHours from '../../components/store/StoreHours';
 import Colors from '../../constants/Colors';
-import { formatPhoneNumber } from '../../lib/authUtils';
 import { openDirections, writeToClipboard } from '../../lib/mapUtils';
 import {
   ColumnContainer,
@@ -30,10 +29,11 @@ export default class StoreDetailsScreen extends React.Component {
   }
 
   render() {
-    const { store, storeOpenStatus } = this.props.route.params;
+    const { store } = this.props.route.params;
     const {
       storeName,
       storeHours,
+      storeOpenStatus,
       address,
       distance,
       ward,
@@ -73,10 +73,10 @@ export default class StoreDetailsScreen extends React.Component {
                 <TouchableOpacity onLongPress={() => writeToClipboard(address)}>
                   <Body>{address}</Body>
                 </TouchableOpacity>
-                <Body>Ward {ward}</Body>
+                <Body>{`Ward ${ward}`}</Body>
                 <View style={{ flex: 1, marginBottom: 10 }}>
                   <Caption style={{ flex: 1 }} color={Colors.secondaryText}>
-                    {distance} miles away · distance may vary by transportation
+                    {`${distance} miles away · distance may vary by transportation`}
                   </Caption>
                 </View>
                 <TouchableOpacity
@@ -101,10 +101,10 @@ export default class StoreDetailsScreen extends React.Component {
           {/* Phone Number */}
           {phoneNumber ? (
             <TouchableOpacity
-              onPress={() => Linking.openURL('tel://'.concat(phoneNumber))}
-              onLongPress={() =>
-                writeToClipboard(formatPhoneNumber(phoneNumber))
-              }>
+              onPress={() =>
+                Linking.openURL('tel://'.concat(phoneNumber.replace(/\D/g, '')))
+              }
+              onLongPress={() => writeToClipboard(phoneNumber)}>
               <InLineContainer
                 style={{ alignItems: 'center', paddingBottom: 32 }}>
                 <FontAwesome5
@@ -113,9 +113,7 @@ export default class StoreDetailsScreen extends React.Component {
                   size={24}
                   color={Colors.activeText}
                 />
-                <Body style={{ marginLeft: 12 }}>
-                  {formatPhoneNumber(phoneNumber)}
-                </Body>
+                <Body style={{ marginLeft: 12 }}>{phoneNumber}</Body>
               </InLineContainer>
             </TouchableOpacity>
           ) : (

--- a/screens/map/StoreDetailsScreen.js
+++ b/screens/map/StoreDetailsScreen.js
@@ -180,8 +180,8 @@ export default class StoreDetailsScreen extends React.Component {
                           style={{ marginTop: -1 }}
                         />
                       )}
-                      textStyle={styles.chipText}
-                      style={styles.chip}>
+                      textStyle={styles.tagChipText}
+                      style={styles.tagChip}>
                       <Caption color={Colors.darkerGreen}>EBT</Caption>
                     </Chip>
                   )}
@@ -195,8 +195,8 @@ export default class StoreDetailsScreen extends React.Component {
                           style={{ marginTop: -1 }}
                         />
                       )}
-                      textStyle={styles.chipText}
-                      style={styles.chip}>
+                      textStyle={styles.tagChipText}
+                      style={styles.tagChip}>
                       <Caption color={Colors.darkerGreen}>WIC</Caption>
                     </Chip>
                   )}
@@ -210,8 +210,8 @@ export default class StoreDetailsScreen extends React.Component {
                           style={{ marginTop: -1 }}
                         />
                       )}
-                      textStyle={styles.chipText}
-                      style={styles.chip}>
+                      textStyle={styles.tagChipText}
+                      style={styles.tagChip}>
                       <Caption color={Colors.darkerGreen}>SNAP Match</Caption>
                     </Chip>
                   )}
@@ -227,8 +227,8 @@ export default class StoreDetailsScreen extends React.Component {
                           style={{ marginTop: -1 }}
                         />
                       )}
-                      textStyle={styles.chipText}
-                      style={styles.chip}>
+                      textStyle={styles.tagChipText}
+                      style={styles.tagChip}>
                       <Caption color={Colors.darkerGreen}>
                         Healthy Rewards
                       </Caption>
@@ -242,26 +242,26 @@ export default class StoreDetailsScreen extends React.Component {
                     maxWidth: '60%',
                   }}>
                   {snapOrEbtAccepted && (
-                    <View style={styles.chipDesc}>
+                    <View style={styles.tagChipDesc}>
                       <Body>Accepts SNAP/EBT</Body>
                     </View>
                   )}
                   {wic && (
-                    <View style={styles.chipDesc}>
+                    <View style={styles.tagChipDesc}>
                       <Body numberOfLines={1} ellipsizeMode="tail">
                         WIC approved
                       </Body>
                     </View>
                   )}
                   {couponProgramPartner && (
-                    <View style={styles.chipDesc}>
+                    <View style={styles.tagChipDesc}>
                       <Body numberOfLines={1} ellipsizeMode="tail">
                         Accepts SNAP Matching
                       </Body>
                     </View>
                   )}
                   {rewardsAccepted && (
-                    <View style={styles.chipDesc}>
+                    <View style={styles.tagChipDesc}>
                       <Body numberOfLines={1} ellipsizeMode="tail">
                         Accepts Healthy Rewards
                       </Body>

--- a/screens/map/StoreListScreen.js
+++ b/screens/map/StoreListScreen.js
@@ -2,9 +2,17 @@ import { FontAwesome5 } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FlatList, ScrollView, View } from 'react-native';
-import { SearchBar } from 'react-native-elements'; // @tommypoa: Create styled-component for this
+import { SearchBar } from 'react-native-elements';
+// @tommypoa: Create styled-component for this
 import { Chip } from 'react-native-paper';
-import { Body, ButtonLabel, Caption, NavHeaderContainer, Title } from '../../components/BaseComponents';
+
+import {
+  Body,
+  ButtonLabel,
+  Caption,
+  NavHeaderContainer,
+  Title,
+} from '../../components/BaseComponents';
 import StoreCard from '../../components/store/StoreCard';
 import Colors from '../../constants/Colors';
 import { ColumnContainer, RowContainer } from '../../styled/shared';
@@ -107,11 +115,15 @@ export default class StoreListScreen extends React.Component {
                 />
               }
               inputStyle={styles.input}
+              // eslint-disable-next-line no-return-assign
               ref={search => (this.search = search)}
             />
           </ColumnContainer>
         </NavHeaderContainer>
-        <ScrollView horizontal style={{ height: 52 }}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={{ height: 52 }}>
           {/* Filter Chips */}
           <Chip
             icon={() => (
@@ -254,7 +266,9 @@ export default class StoreListScreen extends React.Component {
                 solid
                 size={10}
                 color={
-                  filters.rewardsAccepted ? Colors.lightest : Colors.darkerOrange
+                  filters.rewardsAccepted
+                    ? Colors.lightest
+                    : Colors.darkerOrange
                 }
                 style={{ marginTop: 0 }}
               />

--- a/screens/map/StoreListScreen.js
+++ b/screens/map/StoreListScreen.js
@@ -4,13 +4,7 @@ import React from 'react';
 import { FlatList, ScrollView, View } from 'react-native';
 import { SearchBar } from 'react-native-elements'; // @tommypoa: Create styled-component for this
 import { Chip } from 'react-native-paper';
-import {
-  Body,
-  ButtonLabel,
-  Caption,
-  NavHeaderContainer,
-  Title,
-} from '../../components/BaseComponents';
+import { Body, ButtonLabel, Caption, NavHeaderContainer, Title } from '../../components/BaseComponents';
 import StoreCard from '../../components/store/StoreCard';
 import Colors from '../../constants/Colors';
 import { ColumnContainer, RowContainer } from '../../styled/shared';
@@ -19,20 +13,18 @@ import { CancelButton, styles } from '../../styled/store';
 export default class StoreListScreen extends React.Component {
   constructor(props) {
     super(props);
-    const { stores, navigation, showDefaultStore } = this.props.route.params;
+    const { navigation, showDefaultStore } = this.props.route.params;
     this.state = {
-      allStores: stores,
       navigation,
       searchStr: '',
       filters: {
         openNow: false,
         productsInStock: false,
-        ebt: false,
+        snapOrEbtAccepted: false,
         wic: false,
-        snapMatch: false,
-        healthyRewards: false,
+        couponProgramPartner: false,
+        rewardsAccepted: false,
       },
-      filteredStores: stores,
       showDefaultStore,
     };
   }
@@ -49,21 +41,36 @@ export default class StoreListScreen extends React.Component {
     });
   };
 
-  updateSearch = searchStr => {
-    this.setState({
-      searchStr,
-      filteredStores: this.state.allStores.filter(this.filterStore(searchStr)),
-    });
-  };
-
   filterStore = searchStr => {
     return store => {
       return store.storeName.toLowerCase().includes(searchStr.toLowerCase());
     };
   };
 
+  updateFilters = name => {
+    this.setState(prevState => ({
+      filters: { ...prevState.filters, [name]: !prevState.filters[name] },
+    }));
+  };
+
   render() {
-    const { searchStr } = this.state;
+    const { stores } = this.props.route.params;
+    const { filters, searchStr } = this.state;
+    let filteredStores = stores.filter(this.filterStore(searchStr));
+    const selectedFilters = Object.keys(filters).filter(key => filters[key]);
+    // Only apply filters if at least one is selected
+    // Otherwise, apply all that are selected
+    if (selectedFilters.length !== 0) {
+      filteredStores = filteredStores.filter(store => {
+        return selectedFilters.every(name => {
+          // 'Open Now' is not a boolean property that exists
+          if (name === 'openNow') {
+            return store.storeOpenStatus.includes('Open');
+          }
+          return store[name];
+        });
+      });
+    }
 
     return (
       <View>
@@ -86,7 +93,7 @@ export default class StoreListScreen extends React.Component {
               autoCapitalize="words"
               autoCorrect={false}
               placeholder="Search by store name"
-              onChangeText={this.updateSearch}
+              onChangeText={text => this.setState({ searchStr: text })}
               value={searchStr}
               containerStyle={styles.container}
               inputContainerStyle={styles.inputContainer}
@@ -104,47 +111,89 @@ export default class StoreListScreen extends React.Component {
             />
           </ColumnContainer>
         </NavHeaderContainer>
-        <ScrollView horizontal>
-          {/* Chips */}
+        <ScrollView horizontal style={{ height: 52 }}>
+          {/* Filter Chips */}
           <Chip
             icon={() => (
               <FontAwesome5
                 name="clock"
                 solid
                 size={10}
-                color={Colors.darkerOrange}
-                style={{ marginTop: -1 }}
+                color={filters.openNow ? Colors.lightest : Colors.darkerOrange}
+                style={{ marginTop: 0 }}
               />
             )}
-            textStyle={styles.chipText}
-            style={styles.chip}>
-            <Caption color={Colors.darkerOrange}>Open now</Caption>
+            textStyle={styles.filterChipText}
+            style={
+              filters.openNow ? styles.selectedFilterChip : styles.filterChip
+            }
+            onPress={() => {
+              this.updateFilters('openNow');
+            }}>
+            <Caption
+              color={filters.openNow ? Colors.lightest : Colors.darkerOrange}>
+              Open now
+            </Caption>
           </Chip>
           <Chip
             icon={() => (
               <FontAwesome5
                 name="shopping-basket"
                 size={10}
-                color={Colors.darkerOrange}
-                style={{ marginTop: -1 }}
+                color={
+                  filters.productsInStock
+                    ? Colors.lightest
+                    : Colors.darkerOrange
+                }
+                style={{ marginTop: 0 }}
               />
             )}
-            textStyle={styles.chipText}
-            style={styles.chip}>
-            <Caption color={Colors.darkerOrange}>Products in stock</Caption>
+            textStyle={styles.filterChipText}
+            style={
+              filters.productsInStock
+                ? styles.selectedFilterChip
+                : styles.filterChip
+            }
+            onPress={() => {
+              this.updateFilters('productsInStock');
+            }}>
+            <Caption
+              color={
+                filters.productsInStock ? Colors.lightest : Colors.darkerOrange
+              }>
+              Products in stock
+            </Caption>
           </Chip>
           <Chip
             icon={() => (
               <FontAwesome5
                 name="credit-card"
                 size={10}
-                color={Colors.darkerOrange}
-                style={{ marginTop: -1 }}
+                color={
+                  filters.snapOrEbtAccepted
+                    ? Colors.lightest
+                    : Colors.darkerOrange
+                }
+                style={{ marginTop: 0 }}
               />
             )}
-            textStyle={styles.chipText}
-            style={styles.chip}>
-            <Caption color={Colors.darkerOrange}>EBT</Caption>
+            textStyle={styles.filterChipText}
+            style={
+              filters.snapOrEbtAccepted
+                ? styles.selectedFilterChip
+                : styles.filterChip
+            }
+            onPress={() => {
+              this.updateFilters('snapOrEbtAccepted');
+            }}>
+            <Caption
+              color={
+                filters.snapOrEbtAccepted
+                  ? Colors.lightest
+                  : Colors.darkerOrange
+              }>
+              EBT
+            </Caption>
           </Chip>
 
           <Chip
@@ -152,13 +201,19 @@ export default class StoreListScreen extends React.Component {
               <FontAwesome5
                 name="heart"
                 size={10}
-                color={Colors.darkerOrange}
-                style={{ marginTop: -1 }}
+                color={filters.wic ? Colors.lightest : Colors.darkerOrange}
+                style={{ marginTop: 0 }}
               />
             )}
-            textStyle={styles.chipText}
-            style={styles.chip}>
-            <Caption color={Colors.darkerOrange}>WIC</Caption>
+            textStyle={styles.filterChipText}
+            style={filters.wic ? styles.selectedFilterChip : styles.filterChip}
+            onPress={() => {
+              this.updateFilters('wic');
+            }}>
+            <Caption
+              color={filters.wic ? Colors.lightest : Colors.darkerOrange}>
+              WIC
+            </Caption>
           </Chip>
 
           <Chip
@@ -166,13 +221,31 @@ export default class StoreListScreen extends React.Component {
               <FontAwesome5
                 name="carrot"
                 size={10}
-                color={Colors.darkerOrange}
-                style={{ marginTop: -1 }}
+                color={
+                  filters.couponProgramPartner
+                    ? Colors.lightest
+                    : Colors.darkerOrange
+                }
+                style={{ marginTop: 0 }}
               />
             )}
-            textStyle={styles.chipText}
-            style={styles.chip}>
-            <Caption color={Colors.darkerOrange}>SNAP Match</Caption>
+            textStyle={styles.filterChipText}
+            style={
+              filters.couponProgramPartner
+                ? styles.selectedFilterChip
+                : styles.filterChip
+            }
+            onPress={() => {
+              this.updateFilters('couponProgramPartner');
+            }}>
+            <Caption
+              color={
+                filters.couponProgramPartner
+                  ? Colors.lightest
+                  : Colors.darkerOrange
+              }>
+              SNAP Match
+            </Caption>
           </Chip>
           <Chip
             icon={() => (
@@ -180,17 +253,31 @@ export default class StoreListScreen extends React.Component {
                 name="star"
                 solid
                 size={10}
-                color={Colors.darkerOrange}
-                style={{ marginTop: -1 }}
+                color={
+                  filters.rewardsAccepted ? Colors.lightest : Colors.darkerOrange
+                }
+                style={{ marginTop: 0 }}
               />
             )}
-            textStyle={styles.chipText}
-            style={styles.chip}>
-            <Caption color={Colors.darkerOrange}>Healthy Rewards</Caption>
+            textStyle={styles.filterChipText}
+            style={
+              filters.rewardsAccepted
+                ? styles.selectedFilterChip
+                : styles.filterChip
+            }
+            onPress={() => {
+              this.updateFilters('rewardsAccepted');
+            }}>
+            <Caption
+              color={
+                filters.rewardsAccepted ? Colors.lightest : Colors.darkerOrange
+              }>
+              Healthy Rewards
+            </Caption>
           </Chip>
         </ScrollView>
         <FlatList
-          data={this.state.filteredStores}
+          data={filteredStores}
           renderItem={({ item }) => (
             <StoreCard
               key={item.id}

--- a/screens/map/StoreListScreen.js
+++ b/screens/map/StoreListScreen.js
@@ -1,11 +1,13 @@
 import { FontAwesome5 } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { FlatList, View } from 'react-native';
+import { FlatList, ScrollView, View } from 'react-native';
 import { SearchBar } from 'react-native-elements'; // @tommypoa: Create styled-component for this
+import { Chip } from 'react-native-paper';
 import {
   Body,
   ButtonLabel,
+  Caption,
   NavHeaderContainer,
   Title,
 } from '../../components/BaseComponents';
@@ -22,6 +24,14 @@ export default class StoreListScreen extends React.Component {
       allStores: stores,
       navigation,
       searchStr: '',
+      filters: {
+        openNow: false,
+        productsInStock: false,
+        ebt: false,
+        wic: false,
+        snapMatch: false,
+        healthyRewards: false,
+      },
       filteredStores: stores,
       showDefaultStore,
     };
@@ -94,6 +104,91 @@ export default class StoreListScreen extends React.Component {
             />
           </ColumnContainer>
         </NavHeaderContainer>
+        <ScrollView horizontal>
+          {/* Chips */}
+          <Chip
+            icon={() => (
+              <FontAwesome5
+                name="clock"
+                solid
+                size={10}
+                color={Colors.darkerOrange}
+                style={{ marginTop: -1 }}
+              />
+            )}
+            textStyle={styles.chipText}
+            style={styles.chip}>
+            <Caption color={Colors.darkerOrange}>Open now</Caption>
+          </Chip>
+          <Chip
+            icon={() => (
+              <FontAwesome5
+                name="shopping-basket"
+                size={10}
+                color={Colors.darkerOrange}
+                style={{ marginTop: -1 }}
+              />
+            )}
+            textStyle={styles.chipText}
+            style={styles.chip}>
+            <Caption color={Colors.darkerOrange}>Products in stock</Caption>
+          </Chip>
+          <Chip
+            icon={() => (
+              <FontAwesome5
+                name="credit-card"
+                size={10}
+                color={Colors.darkerOrange}
+                style={{ marginTop: -1 }}
+              />
+            )}
+            textStyle={styles.chipText}
+            style={styles.chip}>
+            <Caption color={Colors.darkerOrange}>EBT</Caption>
+          </Chip>
+
+          <Chip
+            icon={() => (
+              <FontAwesome5
+                name="heart"
+                size={10}
+                color={Colors.darkerOrange}
+                style={{ marginTop: -1 }}
+              />
+            )}
+            textStyle={styles.chipText}
+            style={styles.chip}>
+            <Caption color={Colors.darkerOrange}>WIC</Caption>
+          </Chip>
+
+          <Chip
+            icon={() => (
+              <FontAwesome5
+                name="carrot"
+                size={10}
+                color={Colors.darkerOrange}
+                style={{ marginTop: -1 }}
+              />
+            )}
+            textStyle={styles.chipText}
+            style={styles.chip}>
+            <Caption color={Colors.darkerOrange}>SNAP Match</Caption>
+          </Chip>
+          <Chip
+            icon={() => (
+              <FontAwesome5
+                name="star"
+                solid
+                size={10}
+                color={Colors.darkerOrange}
+                style={{ marginTop: -1 }}
+              />
+            )}
+            textStyle={styles.chipText}
+            style={styles.chip}>
+            <Caption color={Colors.darkerOrange}>Healthy Rewards</Caption>
+          </Chip>
+        </ScrollView>
         <FlatList
           data={this.state.filteredStores}
           renderItem={({ item }) => (

--- a/styled/store.js
+++ b/styled/store.js
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native';
 import styled from 'styled-components/native';
+
 import { Body, ButtonContainer } from '../components/BaseComponents';
 import Colors from '../constants/Colors';
 
@@ -110,22 +111,23 @@ export const styles = StyleSheet.create({
   tagChip: {
     backgroundColor: Colors.lightestGreen,
     color: Colors.darkerGreen,
-    marginRight: 6,
     height: 18,
     marginVertical: 0,
+    marginRight: 6,
+    marginBottom: 4,
   },
   filterChip: {
     backgroundColor: Colors.lightestOrange,
     color: Colors.darkerOrange,
-    marginLeft: 6,
     height: 24,
+    marginLeft: 6,
     marginVertical: 10,
   },
   selectedFilterChip: {
     backgroundColor: Colors.primaryOrange,
     color: Colors.lightest,
-    marginLeft: 6,
     height: 24,
+    marginLeft: 6,
     marginVertical: 10,
   },
   tagChipDesc: {

--- a/styled/store.js
+++ b/styled/store.js
@@ -107,23 +107,42 @@ export const styles = StyleSheet.create({
   input: {
     fontFamily: 'poppins-regular',
   },
-  chip: {
+  tagChip: {
     backgroundColor: Colors.lightestGreen,
     color: Colors.darkerGreen,
     marginRight: 6,
-    marginBottom: 4,
     height: 18,
     marginVertical: 0,
   },
-  chipDesc: {
+  filterChip: {
+    backgroundColor: Colors.lightestOrange,
+    color: Colors.darkerOrange,
+    marginLeft: 6,
+    height: 24,
+    marginVertical: 10,
+  },
+  selectedFilterChip: {
+    backgroundColor: Colors.primaryOrange,
+    color: Colors.lightest,
+    marginLeft: 6,
+    height: 24,
+    marginVertical: 10,
+  },
+  tagChipDesc: {
     flex: 1,
     paddingBottom: 10,
     justifyContent: 'center',
   },
-  chipText: {
+  tagChipText: {
     minHeight: 16,
     marginVertical: 0,
     marginTop: 1,
+    lineHeight: 16,
+  },
+  filterChipText: {
+    minHeight: 20,
+    marginVertical: 0,
+    marginTop: 3,
     lineHeight: 16,
   },
 });


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

### In sum
- Added filters for the store list: "Open now", "Products in stock", "EBT", "WIC", "Snap Match", and "Healthy Rewards Accepted".
- Partially waiting on finalized designs, but in its current state it is usable and conforms more-or-less

### Functionality
- Added state object `filters` with various property names that map directly to `store` object properties (except for the `openNow` property).
- Added horizontal scrollview of `Chip` components, selectable
- Implemented filtering so that filters stack, and search is also applied
- Realized that, in a similar manner to how we initially implemented Auth button permissions, we don't need to keep filtered stores in state. Rather, we can just calculate and update the list in the `render` function, since all the information we need is in state.

### Styling
- Updated the chips styling in `styled/store.js`. Most of the work was really done in #98, I just messed around with the heights and margins until things seemed alright.

- Instead of using the `Chip` `built-in` `selected` property, I implemented filter-selection with booleans, since we needed them in state to filter the stores correctly anyway. Also, I couldn't see a good way to switch on `filters[name]` for the styling, text color, _and_ icon color.

### Other details
- Bug fix: moved the formatting for `formatPhoneNumber` into `mapUtils/updateStoreData` into creation of a `phoneNumber` property for stores (when initializing the data)

- In `StoreDetailsScreen`, had to un-format it https://stackoverflow.com/questions/1862130/strip-all-non-numeric-characters-from-string-in-javascript

- Cleanup: created a `storeOpenStatus` property for stores in `mapUtils/updateStoreData` and called `computeOpenHours` to initialize it. This is a string; if it contains `Open` then store is currently open. Removed logic explicitly calling this function outside of `mapUtils`

- Added `productsInStock`, `snapOrEbtMatching`, `couponProgramPartner`, etc boolean fields.
**Airtable does not return fields which are empty / null from the API, so we need to initialize these ourselves if we don't want to run into errors where we expect record objects to contain certain properties**


[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links

### Online sources

Referenced this: https://medium.com/better-programming/creating-a-multi-filter-function-to-filter-out-multiple-attributes-javascript-react-rails-5aad8e272142 (Has a paywall, though)

[//]: # "Optional - copy links to any tutorial or documentation that was useful to you when working on this PR"

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## How to review

Sanity-check that the stores that show up in the list are as expected. Luckily, #98 makes testing this really easy (': Search strings should also stack, as shown in screen recording. 

[//]: # "The order in which to review files and what to expect when testing locally"

## Next steps

Styling: Designs aren't finalized, and though I more or less followed Figma for the initial pixel values the filter chips still seem kind of small.

Code: Pretty sure I should extract the filter chips to a component because the code is so repetitive it drives me a little crazy. At this moment in time I am not really sure how to though since they all have their own functions and icons etc... bit of a headache. No matter what we'll have to do `filters.<filter-type-name>` everywhere. But if we're in a rush to merge this we can refactor it later.

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases

[//]: # "Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally"

### Screenshots

![image](https://user-images.githubusercontent.com/21094576/79683927-71334980-81e2-11ea-995e-51ba2e799176.png)

https://www.loom.com/share/7e47a6ca711b4b139da5b6af4cc07097

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @wangannie

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
