### PR TITLE
Android hide password

### DIFF
--- a/components/AuthTextField.js
+++ b/components/AuthTextField.js
@@ -34,7 +34,7 @@ function AuthTextField({
         error={error}
         errorColor={Colors.error}
         returnKeyType="done"
-        keyboardType={fieldType === 'Phone Number' ? 'numeric' : 'default'}
+        keyboardType={fieldType === 'Phone Number' ? 'numeric' : undefined}
         maxLength={fieldType === 'Phone Number' ? 10 : null}
         secureTextEntry={fieldType === 'Password'}
         labelPadding={6}

--- a/lib/mapUtils.js
+++ b/lib/mapUtils.js
@@ -254,6 +254,7 @@ export function openDirections(latitude, longitude, storeName) {
     latitude,
     longitude,
     title: storeName,
+    googleForceLatLon: true,
     googlePlaceId: 'ChIJW-T2Wt7Gt4kRKl2I1CJFUsI',
     alwaysIncludeGoogle: true,
   });

--- a/lib/mapUtils.js
+++ b/lib/mapUtils.js
@@ -254,7 +254,6 @@ export function openDirections(latitude, longitude, storeName) {
     latitude,
     longitude,
     title: storeName,
-    googleForceLatLon: true,
     googlePlaceId: 'ChIJW-T2Wt7Gt4kRKl2I1CJFUsI',
     alwaysIncludeGoogle: true,
   });

--- a/screens/auth/WelcomeScreen.js
+++ b/screens/auth/WelcomeScreen.js
@@ -50,7 +50,7 @@ export default class WelcomeScreen extends React.Component {
         </FilledButtonContainer>
 
         <ButtonContainer
-          style={{ marginTop: 12 }}
+          style={{ marginTop: 4, padding: 12 }}
           onPress={async () => this.guestLogin()}>
           <ButtonLabel
             style={{ textTransform: 'none' }}


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
* Resolved #112 where `keyboardType` was interfering with `secureTextEntry` on Android and passwords were not hidden.
* Closed #103 ~~where some stores would open directions to the wrong area if the store name matched something closer to the user's current location.~~ Since the forcelatlon fix would pull up the store with ONLY lat/lon without the name (less intuitive), we decided not to address this since it would not be an issue for real users (individuals living in DC).

## Relevant Links

### Online sources
`secureTextEntry` has [known issues ](https://github.com/facebook/react-native/issues/22210) with some `keyboardType`s, but not default. For some reason, setting to default wouldn't work, but `undefined` works.

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## How to review

[//]: # "The order in which to review files and what to expect when testing locally"
On Android, use this link https://exp.host/@wangannie/healthy-corners-rewards-android_auth_fixes to open the published project directly in the Expo app.
* Test to see that the password is correctly hidden for Login and Signup on Android. 
* Try opening Nam's Market and a few other stores in Google Maps and make sure it takes you to the one in DC.


## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases

[//]: # "Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally"

### Screenshots
~~Opening Nam's works properly even when the simulator location is set in Berkeley.~~ Update: removed this
https://www.loom.com/share/e869667902c3469daa7ad970e481dfbc


CC: @anniero98
