### PR TITLE
Add fix for heisenbug Airtable error in MapScreen

### DIFF
--- a/lib/mapUtils.js
+++ b/lib/mapUtils.js
@@ -80,7 +80,6 @@ export function constructHoursDict(hours) {
         console.log(
           '[mapUtils] constructHoursDict: Incorrect store hours formatting in Airtable.'
         );
-        return null;
       }
     });
   }
@@ -212,6 +211,8 @@ function updateStoreData(record) {
     distance: null,
     phoneNumber:
       'phoneNumber' in record ? formatPhoneNumber(record.phoneNumber) : '',
+    // Gracefully handle stores without products
+    productIds: 'productIds' in record ? record.productIds : [],
     // Pre-processing to add these properties to make filtering easier
     storeOpenStatus: computeStoreOpen(record.storeHours),
     productsInStock: 'productIds' in record,
@@ -239,10 +240,6 @@ export async function getStoreData() {
 
 // Gets all products for this store using linked records in Store table from Products table
 export async function getProductData(store) {
-  // Gracefully handle stores without products
-  if (!('productIds' in store)) {
-    return [];
-  }
   const records = await getProductsByIds(store.productIds);
   const storeProducts = records.map(updateProductData);
   return storeProducts;

--- a/screens/map/MapScreen.js
+++ b/screens/map/MapScreen.js
@@ -121,13 +121,15 @@ export default class MapScreen extends React.Component {
   };
 
   _populateStoreProducts = async store => {
-    try {
-      const products = await getProductData(store);
-      if (products) {
-        this.setState({ storeProducts: products });
+    if (store) {
+      try {
+        const products = await getProductData(store);
+        if (products) {
+          this.setState({ storeProducts: products });
+        }
+      } catch (err) {
+        console.error('[MapScreen] (_populateStoreProducts) Airtable:', err);
       }
-    } catch (err) {
-      console.error('[MapScreen] (_populateStoreProducts) Airtable:', err);
     }
   };
 

--- a/screens/map/MapScreen.js
+++ b/screens/map/MapScreen.js
@@ -16,6 +16,7 @@ import StoreMarker from '../../components/store/StoreMarker';
 import Colors from '../../constants/Colors';
 import Window from '../../constants/Layout';
 import RecordIds from '../../constants/RecordIds';
+import { logErrorToSentry } from '../../lib/logUtils';
 import { getProductData, getStoreData } from '../../lib/mapUtils';
 import {
   BottomSheetContainer,
@@ -23,7 +24,6 @@ import {
   DragBar,
   SearchBar,
 } from '../../styled/store';
-import { logErrorToSentry } from '../lib/logUtils';
 
 const minSnapPoint = 185;
 const midSnapPoint = 325;

--- a/screens/map/MapScreen.js
+++ b/screens/map/MapScreen.js
@@ -23,6 +23,7 @@ import {
   DragBar,
   SearchBar,
 } from '../../styled/store';
+import { logErrorToSentry } from '../lib/logUtils';
 
 const minSnapPoint = 185;
 const midSnapPoint = 325;
@@ -117,6 +118,11 @@ export default class MapScreen extends React.Component {
         '[MapScreen] (_populateInitialStoresProducts) Airtable:',
         err
       );
+      logErrorToSentry({
+        screen: 'MapScreen',
+        function: '_populateInitialStoresProducts',
+        error: err,
+      });
     }
   };
 
@@ -129,6 +135,11 @@ export default class MapScreen extends React.Component {
         }
       } catch (err) {
         console.error('[MapScreen] (_populateStoreProducts) Airtable:', err);
+        logErrorToSentry({
+          screen: 'MapScreen',
+          function: '_populateStoreProducts',
+          error: err,
+        });
       }
     }
   };


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

- In `_populateInitialStoreProducts`, the call to `_populateStoreProducts` depends on `setState` for `store` completing. There's a race condition here that we caught w/ Ethan & Thu debugging but the bug is still live in PROD.
- Fixed by adding a null check
- Added (belated) logging to Sentry

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links


### Related PRs

N/A

## How to review

Difficult to reproduce the bug in the first place 😅 

[//]: # "The order in which to review files and what to expect when testing locally"

## Next steps

We should add logging to all the `try/catch` blocks and verify that we are handling all possible promise rejections + add `try/catch` and logging if not. That'll help with diagnosing the white-screen bug (which this may or may not fix)

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases

[//]: # "Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally"

### Screenshots

![image](https://user-images.githubusercontent.com/21094576/80160663-08055a80-8583-11ea-9667-04007c75cc92.png)

This should stop happening

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @wangannie

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
