### PR TITLE
MapScreen Bug Fixes

### DIFF
--- a/screens/map/MapScreen.js
+++ b/screens/map/MapScreen.js
@@ -17,7 +17,12 @@ import Colors from '../../constants/Colors';
 import Window from '../../constants/Layout';
 import RecordIds from '../../constants/RecordIds';
 import { getProductData, getStoreData } from '../../lib/mapUtils';
-import { BottomSheetContainer, BottomSheetHeaderContainer, DragBar, SearchBar } from '../../styled/store';
+import {
+  BottomSheetContainer,
+  BottomSheetHeaderContainer,
+  DragBar,
+  SearchBar,
+} from '../../styled/store';
 
 const minSnapPoint = 160;
 const midSnapPoint = 325;
@@ -104,6 +109,9 @@ export default class MapScreen extends React.Component {
       const stores = await getStoreData();
       // Sets list of stores in state, populates initial products
       await this._orderStoresByDistance(stores);
+
+      // Set current store to be focused
+      this.state.store.focused = true;
       // Once we choose the closest store, we must populate its store products
       // Better to perform API calls at top level, and then pass data as props.
       await this._populateStoreProducts(this.state.store);

--- a/screens/map/MapScreen.js
+++ b/screens/map/MapScreen.js
@@ -216,7 +216,7 @@ export default class MapScreen extends React.Component {
 
     // Animate to new store region
     const region = {
-      latitude: store.latitude,
+      latitude: store.latitude - deltas.latitudeDelta / 3.5,
       longitude: store.longitude,
       ...deltas,
     };
@@ -273,12 +273,14 @@ export default class MapScreen extends React.Component {
             </Subhead>
           </SearchBar>
         </NavHeaderContainer>
-        <CenterLocation
-          callBack={async () => {
-            await this._findCurrentLocation();
-            await this._orderStoresByDistance(this.state.stores);
-          }}
-        />
+        {!this.state.showDefaultStore && (
+          <CenterLocation
+            callBack={async () => {
+              await this._findCurrentLocation();
+              await this._orderStoresByDistance(this.state.stores);
+            }}
+          />
+        )}
         {/* Display Map */}
         <MapView
           style={{
@@ -302,7 +304,9 @@ export default class MapScreen extends React.Component {
               }}
               onPress={() => this.changeCurrentStore(store)}>
               <StoreMarker
-                storeName={store.storeName}
+                storeName={
+                  this.state.region.longitudeDelta < 0.07 ? store.storeName : ''
+                }
                 focused={store.focused}
               />
             </Marker>

--- a/screens/map/MapScreen.js
+++ b/screens/map/MapScreen.js
@@ -5,7 +5,7 @@ import convertDistance from 'geolib/es/convertDistance';
 import getDistance from 'geolib/es/getDistance';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, Image, StyleSheet, TouchableOpacity, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import BottomSheet from 'reanimated-bottom-sheet';
 import { NavHeaderContainer, Subhead } from '../../components/BaseComponents';
@@ -17,12 +17,7 @@ import Colors from '../../constants/Colors';
 import Window from '../../constants/Layout';
 import RecordIds from '../../constants/RecordIds';
 import { getProductData, getStoreData } from '../../lib/mapUtils';
-import {
-  BottomSheetContainer,
-  BottomSheetHeaderContainer,
-  DragBar,
-  SearchBar,
-} from '../../styled/store';
+import { BottomSheetContainer, BottomSheetHeaderContainer, DragBar, SearchBar } from '../../styled/store';
 
 const minSnapPoint = 160;
 const midSnapPoint = 325;
@@ -317,9 +312,12 @@ export default class MapScreen extends React.Component {
               key={coords.latitude
                 .toString()
                 .concat(coords.longitude.toString())}
-              coordinate={coords}
-              image={require('../../assets/images/Current_Location.png')}
-            />
+              coordinate={coords}>
+              <Image
+                style={{ width: 32, height: 32 }}
+                source={require('../../assets/images/Current_Location.png')}
+              />
+            </Marker>
           )}
         </MapView>
         {/* Display bottom sheet. 

--- a/styled/store.js
+++ b/styled/store.js
@@ -15,6 +15,8 @@ export const MarkerStoreName = styled.Text`
   line-height: ${props => (props.focused ? '24px' : '20px')};
   text-align: center
   color: ${Colors.activeText};
+  text-shadow-color: ${Colors.primaryOrange}
+  text-shadow-radius: 5px;
 `;
 
 export const DragBar = styled.View`

--- a/styled/store.js
+++ b/styled/store.js
@@ -15,8 +15,6 @@ export const MarkerStoreName = styled.Text`
   line-height: ${props => (props.focused ? '24px' : '20px')};
   text-align: center
   color: ${Colors.activeText};
-  text-shadow-color: ${Colors.primaryOrange}
-  text-shadow-radius: 5px;
 `;
 
 export const DragBar = styled.View`


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
- Resolves #105 by hiding store name when zoomed out to a certain level
- Store zooms to top-half of screen
- Current location icon size is constant across all screens (Resolves #126 bug: Extra large current location for smaller screen phones)
- Text border/outline for store names
   - Currently has a primary orange color because lighter colors/white does not work 😯
- Resolves #109: Recenter location does not render if
   - There are errors with location fetching (including user disallowing location services)
   - User is too far away

## Relevant Links

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"
- NIL

## How to review

[//]: # "The order in which to review files and what to expect when testing locally"
- Test all new features
   - Location known and unknown situation and whether current location icon is there
   - Check if current location icon of different phone screens is ok
## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"
- Enabling map rotation #81 

## Tests Performed, Edge Cases

[//]: # "Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"
- Hidden store names when zoomed out
![image](https://user-images.githubusercontent.com/35573990/80316318-bd5c3a80-882f-11ea-884c-186215e140e6.png)

- Recenter location button does not show (+ showing default store), featuring the orange text outline 🥵
![image](https://user-images.githubusercontent.com/35573990/80316110-7ae62e00-882e-11ea-8226-866b0e1f9bfa.png)
- Selected store zooms into top half of screen
![image](https://user-images.githubusercontent.com/35573990/80316264-635b7500-882f-11ea-8dce-2e4d98d274ef.png)

CC: @wangannie

[//]: # "This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation."
