### PR TITLE
Fixed edge cases with store hours

### DIFF
--- a/lib/mapUtils.js
+++ b/lib/mapUtils.js
@@ -155,34 +155,40 @@ function computeStoreOpen(hours) {
     const openingTime = hoursSplit[0]; // e.g. "8:30am"
     const closingTime = hoursSplit[1]; // e.g. "8:30pm"
 
-    const openingSuffix = openingTime.slice(-2);
+    const openingSuffix = openingTime.slice(-2).toLowerCase();
     const openingHourMin = openingTime.slice(0, -2);
     const openingHourMinSplit = openingHourMin.split(':');
     let openingHour = parseInt(openingHourMinSplit[0], 10);
     const openingMin =
       openingHourMinSplit.length > 1 ? parseInt(openingHourMinSplit[1], 10) : 0;
 
-    const closingSuffix = closingTime.slice(-2);
+    const closingSuffix = closingTime.slice(-2).toLowerCase();
     const closingHourMin = closingTime.slice(0, -2);
     const closingHourMinSplit = closingHourMin.split(':'); // e.g. ["8", "30"]
     let closingHour = parseInt(closingHourMinSplit[0], 10);
     const closingMin =
       closingHourMinSplit.length > 1 ? parseInt(closingHourMinSplit[1], 10) : 0;
 
+    // Edge case: 11pm-5am Daily (pm before am)
+    // Also consider: Current time is before opening time but same day
     if (openingHour === 12 && openingSuffix === 'am') {
       openingHour -= 12;
     }
 
     // Convert to 24 hour time
-    if (openingSuffix.toLowerCase() === 'pm') {
+    // e.g. 11pm = 23
+    if (openingSuffix === 'pm') {
       openingHour += 12;
     }
 
     if (
-      closingSuffix.toLowerCase() === 'pm' ||
+      closingSuffix === 'pm' ||
       (closingHour === 12 && closingSuffix === 'am')
     ) {
       closingHour += 12;
+    } else if (closingSuffix === 'am') {
+      // e.g. 9am-3am Daily (closes the following day)
+      closingHour += 24;
     }
 
     const convertedOpeningTime = openingHour * 60 + openingMin;
@@ -194,6 +200,11 @@ function computeStoreOpen(hours) {
       currentTime <= convertedClosingTime
     ) {
       return `Open now until ${closingTime}`.replace('12am', 'Midnight');
+    }
+
+    // Store is opening later
+    if (currentTime < convertedOpeningTime) {
+      return `Closed until today ${openingTime}`;
     }
 
     // The store is closed at this time, so we need the next day and its opening time


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
Fixed two edge cases with store hours
- Store is opening later today (e.g. current time is 7:30am, and store opens at 8:30am) --> displays "Closed until today 8:30am"
- Store closes during am hours the next day (e.g. current time is 11pm, and store closes at 5am the next day) --> displays "Open until 5am"

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review
I changed Market 77's hours to be "9pm-5am Daily" as an edge case. Check out the store hours for that store to make sure that (1) the store summary string makes sense and (2) the correct day is bolded in the schedule.

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
#96 
Closes #140 

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps
Just...lmk if there are more store hours bugs I guess...

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots
![IMG_2783](https://user-images.githubusercontent.com/21699109/80677456-c20e3200-8a6d-11ea-965d-c84b972f8a60.PNG)
![IMG_2784](https://user-images.githubusercontent.com/21699109/80677460-c4708c00-8a6d-11ea-800b-d435e552214c.PNG)

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @anniero98 @wangannie

[//]: # 'This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
