### PR TITLE
Hamburger menu updates

### DIFF
--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -5,10 +5,10 @@ import * as Analytics from 'expo-firebase-analytics';
 import React from 'react';
 import Colors from '../constants/Colors';
 import AuthLoadingScreen from '../screens/auth/AuthLoadingScreen';
-import RewardsScreen from '../screens/rewards/RewardsScreen';
 import DrawerContent from './DrawerContent';
 import AuthStackNavigator from './stack_navigators/AuthStack';
 import ResourcesStackNavigator from './stack_navigators/ResourcesStack';
+import RewardsStackNavigator from './stack_navigators/RewardsStack';
 import StoresStackNavigator from './stack_navigators/StoresStack';
 
 const Drawer = createDrawerNavigator();
@@ -43,13 +43,16 @@ function DrawerNavigator() {
       <Drawer.Screen
         name="Stores"
         component={StoresStackNavigator}
-        options={{ title: 'Stores', swipeEnabled: false }}
+        options={{ title: 'Map', swipeEnabled: false }}
       />
       <Drawer.Screen
         name="Rewards"
-        options={{ title: 'Rewards', drawerLockMode: 'locked-closed' }}>
-        {(props) => <RewardsScreen {...props} tab={1} />}
-      </Drawer.Screen>
+        component={RewardsStackNavigator}
+        options={{
+          title: 'Rewards',
+          drawerLockMode: 'locked-closed',
+        }}
+      />
       <Drawer.Screen
         name="Resources"
         component={ResourcesStackNavigator}

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -5,6 +5,7 @@ import * as Analytics from 'expo-firebase-analytics';
 import React from 'react';
 import Colors from '../constants/Colors';
 import AuthLoadingScreen from '../screens/auth/AuthLoadingScreen';
+import RewardsScreen from '../screens/rewards/RewardsScreen';
 import DrawerContent from './DrawerContent';
 import AuthStackNavigator from './stack_navigators/AuthStack';
 import ResourcesStackNavigator from './stack_navigators/ResourcesStack';
@@ -44,11 +45,11 @@ function DrawerNavigator() {
         component={StoresStackNavigator}
         options={{ title: 'Stores', swipeEnabled: false }}
       />
-      {/* <Drawer.Screen
+      <Drawer.Screen
         name="Rewards"
-        options={{ title: 'Points History', drawerLockMode: 'locked-closed' }}>
-        {props => <RewardsScreen {...props} tab={1} />}
-      </Drawer.Screen> */}
+        options={{ title: 'Rewards', drawerLockMode: 'locked-closed' }}>
+        {(props) => <RewardsScreen {...props} tab={1} />}
+      </Drawer.Screen>
       <Drawer.Screen
         name="Resources"
         component={ResourcesStackNavigator}

--- a/navigation/DrawerContent.js
+++ b/navigation/DrawerContent.js
@@ -107,6 +107,11 @@ function DrawerContent(props) {
         <Title style={{ color: 'white' }}>{customer.name}</Title>
       </View>
       <DrawerItemList {...props} />
+      <TouchableOpacity
+        style={{ padding: 8, height: 114 }}
+        onPress={() => Linking.openURL(link)}>
+        <Title>Feedback</Title>
+      </TouchableOpacity>
       <View
         style={{
           flex: 1,
@@ -114,11 +119,6 @@ function DrawerContent(props) {
           justifyContent: 'flex-end',
           verticalAlign: 'bottom',
         }}>
-        <TouchableOpacity
-          style={{ padding: 16 }}
-          onPress={() => Linking.openURL(link)}>
-          <Title>Report Issue</Title>
-        </TouchableOpacity>
         <TouchableOpacity
           style={{ paddingLeft: 16, paddingBottom: 21 }}
           onPress={() => logout()}>

--- a/navigation/stack_navigators/ResourcesStack.js
+++ b/navigation/stack_navigators/ResourcesStack.js
@@ -17,7 +17,7 @@ export default function ResourcesStackNavigator() {
   return (
     <ResourcesStack.Navigator
       screenOptions={{
-        drawerLabel: 'Rewards',
+        drawerLabel: 'Resources',
         headerShown: false,
         cardStyle: { backgroundColor: Colors.lightest },
         config,

--- a/navigation/stack_navigators/RewardsStack.js
+++ b/navigation/stack_navigators/RewardsStack.js
@@ -1,0 +1,44 @@
+import {
+  CardStyleInterpolators,
+  createStackNavigator,
+} from '@react-navigation/stack';
+import React from 'react';
+import { Platform } from 'react-native';
+import { useSafeArea } from 'react-native-safe-area-context';
+import Colors from '../../constants/Colors';
+import RewardsScreen from '../../screens/rewards/RewardsScreen';
+
+const config = Platform.select({
+  web: { headerMode: 'screen' },
+  default: {
+    headerMode: 'none',
+  },
+});
+
+const RewardsStack = createStackNavigator();
+
+export default function RewardsStackNavigator() {
+  return (
+    <RewardsStack.Navigator
+      screenOptions={{
+        cardOverlayEnabled: true,
+        drawerLabel: 'Rewards',
+        gestureEnabled: true,
+        headerShown: false,
+        cardStyle: { backgroundColor: Colors.lightest },
+        config,
+      }}>
+      <RewardsStack.Screen
+        name="RewardsOverlay"
+        component={RewardsScreen}
+        options={{
+          cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+          gestureDirection: 'vertical',
+          gestureResponseDistance: {
+            vertical: 162 + useSafeArea().top,
+          },
+        }}
+      />
+    </RewardsStack.Navigator>
+  );
+}


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
- Updated `MapScreen` drawer label from "Stores" to "Map"
- Moved "Feedback" to top half portion of tabs

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review
Hamburger menu tabs should still operate as usual.

Use this [Expo link ](https://exp.host/@wangannie/healthy-corners-rewards-android-hamburger-menu) to test on Android

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps
If possible, figure out how to make `StoresList` a tab in the hamburger menu. I made some progress in this (and `git stash`ed it), up until the point where the tab displays and navigates to the stores list with all stores loaded in alphabetical order, but the changes made cause more problems than the good it'll do, so we're gonna backlog this for now. :(

Namely, when clicking on store cards, the map screen doesn't update the current store. Also, the tab doesn't always navigate to the `StoresList` screen.

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots
![IMG_2803](https://user-images.githubusercontent.com/21699109/81248723-def8b700-8fd1-11ea-9c3f-5f614e2a0068.PNG)

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @anniero98 @wangannie

[//]: # 'This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
