### PR TITLE
WelcomeScreen button bugfix 

### DIFF
--- a/screens/auth/WelcomeScreen.js
+++ b/screens/auth/WelcomeScreen.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { AsyncStorage, Image } from 'react-native';
 import {
-  ButtonContainer,
   ButtonLabel,
   FilledButtonContainer,
 } from '../../components/BaseComponents';
@@ -48,8 +47,24 @@ export default class WelcomeScreen extends React.Component {
           onPress={() => this.navigateLogIn()}>
           <ButtonLabel color="white">Log In</ButtonLabel>
         </FilledButtonContainer>
+        <FilledButtonContainer
+          style={{ marginTop: 12 }}
+          color={Colors.lighterGreen}
+          width="100%"
+          onPress={() => this.guestLogin()}>
+          <ButtonLabel color="white">guestguest</ButtonLabel>
+        </FilledButtonContainer>
+        <FilledButtonContainer
+          style={{ marginTop: 6 }}
+          color="transparent"
+          width="100%"
+          onPress={() => this.navigateSignup()}>
+          <ButtonLabel color={Colors.primaryGreen}>
+            guestmotherfucker
+          </ButtonLabel>
+        </FilledButtonContainer>
 
-        <ButtonContainer
+        {/* <ButtonContainer
           style={{ marginTop: 4, padding: 12 }}
           onPress={async () => this.guestLogin()}>
           <ButtonLabel
@@ -57,7 +72,7 @@ export default class WelcomeScreen extends React.Component {
             color={Colors.primaryGreen}>
             Continue without an account
           </ButtonLabel>
-        </ButtonContainer>
+        </ButtonContainer> */}
       </WelcomeContainer>
     );
   }

--- a/screens/auth/WelcomeScreen.js
+++ b/screens/auth/WelcomeScreen.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { AsyncStorage, Image } from 'react-native';
+import { AsyncStorage, Image, View } from 'react-native';
 import {
+  ButtonContainer,
   ButtonLabel,
   FilledButtonContainer,
 } from '../../components/BaseComponents';
@@ -26,53 +27,46 @@ export default class WelcomeScreen extends React.Component {
   render() {
     return (
       <WelcomeContainer>
-        <Image
-          source={require('../../assets/images/hc_start.png')}
+        {/* Welcome Image */}
+        <View
           style={{
-            maxWidth: '100%',
-            resizeMode: 'contain',
-            maxHeight: 400,
-          }}
-        />
-        <FilledButtonContainer
-          style={{ marginTop: 108 }}
-          width="100%"
-          onPress={() => this.navigateSignup()}>
-          <ButtonLabel color="white">Sign up</ButtonLabel>
-        </FilledButtonContainer>
-        <FilledButtonContainer
-          style={{ marginTop: 12 }}
-          color={Colors.lighterGreen}
-          width="100%"
-          onPress={() => this.navigateLogIn()}>
-          <ButtonLabel color="white">Log In</ButtonLabel>
-        </FilledButtonContainer>
-        <FilledButtonContainer
-          style={{ marginTop: 12 }}
-          color={Colors.lighterGreen}
-          width="100%"
-          onPress={() => this.guestLogin()}>
-          <ButtonLabel color="white">guestguest</ButtonLabel>
-        </FilledButtonContainer>
-        <FilledButtonContainer
-          style={{ marginTop: 6 }}
-          color="transparent"
-          width="100%"
-          onPress={() => this.navigateSignup()}>
-          <ButtonLabel color={Colors.primaryGreen}>
-            guestmotherfucker
-          </ButtonLabel>
-        </FilledButtonContainer>
-
-        {/* <ButtonContainer
-          style={{ marginTop: 4, padding: 12 }}
-          onPress={async () => this.guestLogin()}>
-          <ButtonLabel
-            style={{ textTransform: 'none' }}
-            color={Colors.primaryGreen}>
-            Continue without an account
-          </ButtonLabel>
-        </ButtonContainer> */}
+            height: '60%',
+            justifyContent: 'flex-end',
+          }}>
+          <Image
+            source={require('../../assets/images/hc_start.png')}
+            style={{
+              maxWidth: '100%',
+              resizeMode: 'contain',
+              maxHeight: 400,
+            }}
+          />
+        </View>
+        {/* Buttons */}
+        <View style={{ width: '100%' }}>
+          <FilledButtonContainer
+            style={{ marginTop: 12 }}
+            width="100%"
+            onPress={() => this.navigateSignup()}>
+            <ButtonLabel color="white">Sign up</ButtonLabel>
+          </FilledButtonContainer>
+          <FilledButtonContainer
+            style={{ marginTop: 12 }}
+            color={Colors.lighterGreen}
+            width="100%"
+            onPress={() => this.navigateLogIn()}>
+            <ButtonLabel color="white">Log In</ButtonLabel>
+          </FilledButtonContainer>
+          <ButtonContainer
+            style={{ marginTop: 4, padding: 12 }}
+            onPress={async () => this.guestLogin()}>
+            <ButtonLabel
+              style={{ textTransform: 'none' }}
+              color={Colors.primaryGreen}>
+              Continue without an account
+            </ButtonLabel>
+          </ButtonContainer>
+        </View>
       </WelcomeContainer>
     );
   }

--- a/styled/auth.js
+++ b/styled/auth.js
@@ -36,10 +36,11 @@ export const OnboardingContainer = styled.View`
 // TODO @tommypoa: margin-top should be corrected to sit right above keyboard (as in LogIn and SignUp screens)
 export const WelcomeContainer = styled.View`
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  background-color: ${Colors.lightest};
-  margin: 240px 42px;
+  flex: 1;
+  margin-horizontal: 42px;
+  padding-bottom: 75px;
 `;
 
 // LogInScreen


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
Fixed #118 where Android users could not select 'Continue without an account'. 

**Problem**
At first, I thought this was an issue with the TouchableOpacity, but when I checked with the inspector, I realized it was because the buttons were overflowing the container. That was why I couldn't recreate it on my emulator until I added extra buttons, pushing it out of the container (stimulating the spacing that @12aschen had on a Pixel 2). We assumed this was an Android-specific issue, but when I tested it on an iPhone SE, the buttons also overflowed the container. It turns out that on iOS, buttons that overflow are still clickable, so we never noticed this issue before. The core issue is that the container had static pixel margins that couldn't accommodate smaller devices.

<img src="https://user-images.githubusercontent.com/21160510/81444089-6b6abd00-912b-11ea-9063-8402bfe468c1.png" width="250px"/> <img src="https://user-images.githubusercontent.com/21160510/81448765-cdc7bb80-9133-11ea-83ff-2698a97daa93.png" width="250px"/>

**Solution**
I rearranged the WelcomeScreen containers to be `space-between` containing two Views for the image and buttons with a bottom padding to make sure the buttons will never get pushed out. I gave the top image view a dynamic height (60%) because it seemed to have TOO much space on large phones, but looked way too squished on small phones. Now, the image should always be approximately centered with the buttons 75px from the bottom, not overflowing the container, so they should always be clickable no matter what screen size/aspect ratio.

## How to review
Test on Android using [this link](https://exp.host/@wangannie/healthy-corners-rewards-android-guest-fix) and make sure all buttons work properly.

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links
#118 

### Online sources
n/a

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
n/a

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps
* It will be important to keep this in mind for the onboarding screens that currently also use static margins all around. We may need to adjust the spacing and margins of that container @tommypoa 

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @anniero98

[//]: # 'This tags in both Annies as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
