### PR TITLE
Set password after registering in-store + phone number input formatting

### DIFF
--- a/components/AuthTextField.js
+++ b/components/AuthTextField.js
@@ -37,13 +37,13 @@ function AuthTextField({
         keyboardType={
           fieldType.includes('Phone Number') ||
           fieldType === 'Verification Code'
-            ? 'numeric'
+            ? 'number-pad'
             : undefined
         }
         maxLength={
           // eslint-disable-next-line no-nested-ternary
           fieldType.includes('Phone Number')
-            ? 10
+            ? 14
             : fieldType === 'Verification Code'
             ? 6
             : null

--- a/components/resources/CategoryBar.js
+++ b/components/resources/CategoryBar.js
@@ -8,12 +8,14 @@ import CircleIcon from '../CircleIcon';
 function CategoryBar({ icon, title }) {
   return (
     <CategoryCard>
-      <CircleIcon
-        icon={icon}
-        iconColor={Colors.lightText}
-        circleColor={Colors.lighterGreen}
-      />
-      <CategoryHeadingContainer>
+      {icon !== '' && (
+        <CircleIcon
+          icon={icon}
+          iconColor={Colors.lightText}
+          circleColor={Colors.lighterGreen}
+        />
+      )}
+      <CategoryHeadingContainer style={icon !== '' && { marginLeft: 12 }}>
         <Title>{title}</Title>
       </CategoryHeadingContainer>
     </CategoryCard>
@@ -21,8 +23,12 @@ function CategoryBar({ icon, title }) {
 }
 
 CategoryBar.propTypes = {
-  icon: PropTypes.string.isRequired,
+  icon: PropTypes.string,
   title: PropTypes.string.isRequired,
+};
+
+CategoryBar.defaultProps = {
+  icon: '',
 };
 
 export default CategoryBar;

--- a/components/rewards/RewardsFooter.js
+++ b/components/rewards/RewardsFooter.js
@@ -75,7 +75,7 @@ export default class RewardsFooter extends React.Component {
                 ? `${this.state.rewards} rewards`
                 : this.state.customer.points === 1
                 ? `${this.state.customer.points} point`
-                : `${this.state.customer.points} points`}
+                : `${this.state.customer.points || 0} points`}
             </Subtitle>
           </View>
         )}

--- a/components/rewards/RewardsHome.js
+++ b/components/rewards/RewardsHome.js
@@ -36,7 +36,7 @@ function RewardsHome({ customer, participating }) {
           Reward Progress
         </Overline>
         <Title style={{ marginBottom: 2 }}>
-          {`${pointsToNext} / ${rewardPointValue}`}
+          {`${pointsToNext || 0} / ${rewardPointValue}`}
         </Title>
         <ProgressBar
           style={{

--- a/components/settings/SettingsCard.js
+++ b/components/settings/SettingsCard.js
@@ -1,10 +1,21 @@
+import { FontAwesome5 } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Colors from '../../constants/Colors';
-import { ContentContainer, ResourceItemCard } from '../../styled/resources';
+import {
+  ContentContainer,
+  IconContainer,
+  ResourceItemCard,
+} from '../../styled/resources';
 import { Body, ButtonContainer, Subtitle } from '../BaseComponents';
 
-function SettingsCard({ title, description, navigation, titleColor }) {
+function SettingsCard({
+  title,
+  description,
+  navigation,
+  titleColor,
+  rightIcon,
+}) {
   return (
     <ButtonContainer onPress={() => navigation()}>
       <ResourceItemCard>
@@ -14,6 +25,15 @@ function SettingsCard({ title, description, navigation, titleColor }) {
             <Body color={Colors.secondaryText}>{description}</Body>
           )}
         </ContentContainer>
+        {rightIcon !== '' && (
+          <IconContainer>
+            <FontAwesome5
+              name={rightIcon}
+              size={24}
+              color={Colors.primaryGray}
+            />
+          </IconContainer>
+        )}
       </ResourceItemCard>
     </ButtonContainer>
   );
@@ -24,11 +44,13 @@ SettingsCard.propTypes = {
   titleColor: PropTypes.string,
   description: PropTypes.string,
   navigation: PropTypes.func.isRequired,
+  rightIcon: PropTypes.string,
 };
 
 SettingsCard.defaultProps = {
   titleColor: Colors.activeText,
   description: '',
+  rightIcon: '',
 };
 
 export default SettingsCard;

--- a/constants/Rewards.js
+++ b/constants/Rewards.js
@@ -1,2 +1,3 @@
 export const rewardDollarValue = 5;
 export const rewardPointValue = 500;
+export const signUpBonus = 500;

--- a/lib/authUtils.js
+++ b/lib/authUtils.js
@@ -1,4 +1,8 @@
 import * as Crypto from 'expo-crypto';
+import {
+  formatIncompletePhoneNumber,
+  parsePhoneNumberFromString,
+} from 'libphonenumber-js';
 import { createPushTokens, updateCustomers } from './airtable/request';
 import { logErrorToSentry } from './logUtils';
 // Fields
@@ -54,11 +58,21 @@ export async function updateCustomerPushTokens(customer, newToken) {
   }
 }
 
+// Formats full phone numbers by (...) ...-.... or returns null if the number is not 10 digits
 export function formatPhoneNumber(phoneNumber) {
-  const onlyNumeric = phoneNumber.replace('[^0-9]', '');
-  const formatted = `(${onlyNumeric.slice(0, 3)}) ${onlyNumeric.slice(
-    3,
-    6
-  )}-${onlyNumeric.slice(6, 10)}`;
+  const parsedPhoneNumber = parsePhoneNumberFromString(`+1${phoneNumber}`);
+  if (parsedPhoneNumber && parsedPhoneNumber.isPossible()) {
+    return parsedPhoneNumber.formatNational();
+  }
+  return null;
+}
+
+// Automatically formats phone number input to (...) ...-.... as the user types
+export function formatPhoneNumberInput(text) {
+  let formatted = formatIncompletePhoneNumber(text, 'US');
+  // Workaround for a bug that doesn't allow backspacing the closing parenthesis
+  if (formatted.slice(-1) === ')') {
+    formatted = formatted.slice(0, -1);
+  }
   return formatted;
 }

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -29,7 +29,6 @@ function DrawerNavigator() {
     <Drawer.Navigator
       // eslint-disable-next-line react/jsx-props-no-spreading
       drawerContent={(props) => <DrawerContent {...props} />}
-      drawerStyle={{ width: 189 }}
       drawerContentOptions={{
         labelStyle: {
           fontFamily: 'poppins-medium',
@@ -38,7 +37,12 @@ function DrawerNavigator() {
           color: Colors.activeText,
         },
         activeTintColor: Colors.primaryGreen,
-        itemStyle: { marginVertical: 0, marginHorizontal: 0, borderRadius: 0 },
+        itemStyle: {
+          marginVertical: 4,
+          marginHorizontal: 0,
+          paddingLeft: 16,
+          borderRadius: 0,
+        },
       }}>
       <Drawer.Screen
         name="Stores"
@@ -48,12 +52,18 @@ function DrawerNavigator() {
       <Drawer.Screen
         name="Resources"
         component={ResourcesStackNavigator}
-        options={{ title: 'Resources', swipeEnabled: false }}
+        options={{
+          title: 'Resources',
+          unmountOnBlur: true,
+        }}
       />
       <Drawer.Screen
         name="Settings"
         component={SettingsStackNavigator}
-        options={{ title: 'Settings', swipeEnabled: false }}
+        options={{
+          title: 'Settings',
+          unmountOnBlur: true,
+        }}
       />
     </Drawer.Navigator>
   );

--- a/navigation/DrawerContent.js
+++ b/navigation/DrawerContent.js
@@ -1,30 +1,33 @@
 import { DrawerItemList } from '@react-navigation/drawer';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { Updates } from 'expo';
+import { useFocusEffect } from '@react-navigation/native';
 import * as Analytics from 'expo-firebase-analytics';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert, AsyncStorage, Linking, View } from 'react-native';
 import * as Sentry from 'sentry-expo';
-import { ButtonContainer, Title } from '../components/BaseComponents';
+import {
+  BigTitle,
+  ButtonContainer,
+  ButtonLabel,
+  FilledButtonContainer,
+  Subtitle,
+  Title,
+} from '../components/BaseComponents';
 import Colors from '../constants/Colors';
 import { getCustomersById } from '../lib/airtable/request';
 import { logErrorToSentry } from '../lib/logUtils';
+import { ColumnContainer, SpaceBetweenRowContainer } from '../styled/shared';
 
 function DrawerContent(props) {
   const [customer, setCustomer] = React.useState(null);
   const [link, _] = React.useState('http://tiny.cc/RewardsFeedback');
   const [isLoading, setIsLoading] = React.useState(true);
-  const navigation = useNavigation();
 
   const logout = async () => {
+    props.navigation.navigate('Stores');
     await AsyncStorage.clear();
     Sentry.configureScope((scope) => scope.clear());
-    setTimeout(() => {
-      navigation.navigate('Auth');
-    }, 500);
-    props.navigation.closeDrawer();
-    Updates.reload();
+    props.navigation.navigate('Auth', { screen: 'LogIn' });
   };
 
   useFocusEffect(
@@ -96,6 +99,8 @@ function DrawerContent(props) {
     return null;
   }
 
+  const isGuest = customer.name === 'Guest';
+
   return (
     <View
       style={{
@@ -105,40 +110,69 @@ function DrawerContent(props) {
       }}>
       <View
         style={{
-          backgroundColor: Colors.bgDark,
-          height: 114,
+          backgroundColor: isGuest ? Colors.bgDark : Colors.primaryGreen,
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'flex-end',
-          padding: 8,
+          padding: 24,
+          marginBottom: 24,
         }}>
-        <Title style={{ color: Colors.lightText }}>{customer.name}</Title>
+        <ColumnContainer style={{ marginTop: 32, width: '100%' }}>
+          <SpaceBetweenRowContainer
+            style={{ alignItems: 'center', marginBottom: 4, width: '100%' }}>
+            <BigTitle style={{ color: Colors.lightText }}>
+              {customer.name}
+            </BigTitle>
+            {isGuest && (
+              <FilledButtonContainer
+                style={{
+                  borderColor: Colors.lightText,
+                  borderWidth: 1,
+                  height: 30,
+                  width: 80,
+                  marginVertical: 8,
+                  marginRight: 8,
+                }}
+                color={Colors.bgLight}
+                onPress={() => {
+                  logout();
+                }}>
+                <ButtonLabel noCaps>Log In</ButtonLabel>
+              </FilledButtonContainer>
+            )}
+          </SpaceBetweenRowContainer>
+          {isGuest && (
+            <Subtitle style={{ color: Colors.lightText }}>
+              Log in to start saving with Healthy Rewards
+            </Subtitle>
+          )}
+        </ColumnContainer>
       </View>
-      <DrawerItemList {...props} />
       <ButtonContainer
-        style={{ paddingHorizontal: 8, paddingVertical: 13 }}
+        style={{ paddingLeft: 24, paddingVertical: 13 }}
         onPress={() => {
           props.navigation.goBack();
-          props.navigation.navigate('RewardsOverlay');
+          setTimeout(
+            () =>
+              props.navigation.navigate('Stores', { screen: 'RewardsOverlay' }),
+            700
+          );
         }}>
-        <Title style={{ height: 30 }}>Rewards</Title>
+        <Title style={{ height: 30 }}>Healthy Rewards</Title>
       </ButtonContainer>
-      <ButtonContainer
-        style={{ paddingHorizontal: 8, paddingVertical: 13 }}
-        onPress={() => Linking.openURL(link)}>
-        <Title style={{ height: 30 }}>Feedback</Title>
-      </ButtonContainer>
+      <DrawerItemList {...props} />
       <View
         style={{
           flex: 1,
           flexDirection: 'column',
           justifyContent: 'flex-end',
           verticalAlign: 'bottom',
+          paddingBottom: 20,
         }}>
         <ButtonContainer
-          style={{ paddingLeft: 16, paddingBottom: 21 }}
-          onPress={() => logout()}>
-          <Title>Log Out</Title>
+          style={{ paddingLeft: 24, paddingVertical: 13 }}
+          onPress={() => Linking.openURL(link)}>
+          <Subtitle style={{ height: 30 }}>Submit feedback</Subtitle>
         </ButtonContainer>
       </View>
     </View>

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "geolib": "^3.1.0",
     "global": "^4.4.0",
     "install": "^0.13.0",
+    "libphonenumber-js": "^1.7.52",
     "npm": "^6.13.4",
     "prop-types": "^15.0",
     "react": "16.9.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-geocode": "^0.2.0",
     "react-is": "^16.12.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz",
+    "react-native-alert-async": "^1.0.5",
     "react-native-elements": "^1.2.6",
     "react-native-firebase": "^5.6.0",
     "react-native-gesture-handler": "~1.6.0",

--- a/screens/auth/LogInScreen.js
+++ b/screens/auth/LogInScreen.js
@@ -1,4 +1,5 @@
 import { FontAwesome5 } from '@expo/vector-icons';
+import { StackActions } from '@react-navigation/native';
 import { Notifications } from 'expo';
 import Constants from 'expo-constants';
 import * as Analytics from 'expo-firebase-analytics';
@@ -10,10 +11,12 @@ import * as Sentry from 'sentry-expo';
 import AuthTextField from '../../components/AuthTextField';
 import {
   BigTitle,
+  Body,
   ButtonContainer,
   ButtonLabel,
   Caption,
   FilledButtonContainer,
+  Subtitle,
 } from '../../components/BaseComponents';
 import Colors from '../../constants/Colors';
 import { getCustomersByPhoneNumber } from '../../lib/airtable/request';
@@ -30,7 +33,7 @@ import {
   BackButton,
   FormContainer,
 } from '../../styled/auth';
-import { JustifyCenterContainer } from '../../styled/shared';
+import { JustifyCenterContainer, RowContainer } from '../../styled/shared';
 import validate from './validation';
 
 export default class LogInScreen extends React.Component {
@@ -100,6 +103,27 @@ export default class LogInScreen extends React.Component {
       // Phone number is registered
       if (customers.length === 1) {
         [customer] = customers;
+        if (!customer.password) {
+          Alert.alert(
+            'Phone number registered without a password',
+            `${
+              this.state.values[inputFields.PHONENUM]
+            } does not have a password yet. Set a password to finish setting up your account.`,
+            [
+              {
+                text: 'Set a password',
+                onPress: () =>
+                  this.props.navigation.navigate('Reset', {
+                    forgot: false,
+                  }),
+              },
+              {
+                text: 'Cancel',
+                style: 'cancel',
+              },
+            ]
+          );
+        }
 
         // Check if password is correct
         // We use the record ID from Airtable as the salt to encrypt
@@ -240,6 +264,18 @@ export default class LogInScreen extends React.Component {
             <FontAwesome5 name="arrow-left" solid size={24} />
           </BackButton>
           <BigTitle>Log In</BigTitle>
+          <Subtitle style={{ marginTop: 32 }}>
+            {'If you registered in person with your phone number, '}
+            <Subtitle
+              color={Colors.primaryGreen}
+              onPress={() =>
+                this.props.navigation.navigate('Reset', { forgot: false })
+              }>
+              click here to set a password
+            </Subtitle>
+            {' to finish setting up your account.'}
+          </Subtitle>
+
           <FormContainer>
             <AuthTextField
               fieldType="Phone Number"
@@ -261,6 +297,15 @@ export default class LogInScreen extends React.Component {
               }
               error={this.state.errors[inputFields.PASSWORD]}
             />
+            <ButtonContainer
+              style={{ alignSelf: 'left', marginTop: -12, marginBottom: 12 }}
+              onPress={async () =>
+                this.props.navigation.navigate('Reset', { forgot: true })
+              }>
+              <ButtonLabel noCaps color={Colors.secondaryText}>
+                Forgot Password?
+              </ButtonLabel>
+            </ButtonContainer>
             <Caption
               style={{ alignSelf: 'center', fontSize: 14 }}
               color={Colors.error}>
@@ -269,7 +314,7 @@ export default class LogInScreen extends React.Component {
           </FormContainer>
           <JustifyCenterContainer>
             <FilledButtonContainer
-              style={{ marginTop: 24 }}
+              style={{ marginTop: 24, marginBottom: 12 }}
               color={
                 !logInPermission ? Colors.lightestGreen : Colors.primaryGreen
               }
@@ -278,17 +323,20 @@ export default class LogInScreen extends React.Component {
               disabled={!logInPermission}>
               <ButtonLabel color={Colors.lightText}>Log in</ButtonLabel>
             </FilledButtonContainer>
-            <ButtonContainer
-              onPress={async () =>
-                this.props.navigation.navigate('Reset', { forgot: true })
-              }>
-              <ButtonLabel
-                noCaps
-                style={{ marginVertical: 12 }}
-                color={Colors.primaryGreen}>
-                Forgot Password?
-              </ButtonLabel>
-            </ButtonContainer>
+            <RowContainer
+              style={{
+                justifyContent: 'center',
+              }}>
+              <Body>Don&apos;t have an account?</Body>
+              <ButtonContainer
+                onPress={() =>
+                  this.props.navigation.dispatch(StackActions.replace('SignUp'))
+                }>
+                <ButtonLabel noCaps color={Colors.primaryGreen}>
+                  Sign Up
+                </ButtonLabel>
+              </ButtonContainer>
+            </RowContainer>
           </JustifyCenterContainer>
         </AuthScrollContainer>
       </AuthScreenContainer>

--- a/screens/auth/LogInScreen.js
+++ b/screens/auth/LogInScreen.js
@@ -327,7 +327,7 @@ export default class LogInScreen extends React.Component {
               style={{
                 justifyContent: 'center',
               }}>
-              <Body>Don&apos;t have an account?</Body>
+              <Body>{`Don't have an account? `}</Body>
               <ButtonContainer
                 onPress={() =>
                   this.props.navigation.dispatch(StackActions.replace('SignUp'))

--- a/screens/auth/PasswordResetScreen.js
+++ b/screens/auth/PasswordResetScreen.js
@@ -218,7 +218,7 @@ export default class PasswordResetScreen extends React.Component {
         }
         this.setState({ customer });
       } else {
-        const errorMsg = 'There is no account registered with this number';
+        const errorMsg = 'No account registered with this number';
         this.setState((prevState) => ({
           errors: { ...prevState.errors, [inputFields.PHONENUM]: errorMsg },
         }));
@@ -368,7 +368,9 @@ export default class PasswordResetScreen extends React.Component {
             <View>
               <BigTitle>Success!</BigTitle>
               <Subtitle style={{ marginTop: 32 }}>
-                Your new password was successfully set.
+                {this.state.forgot
+                  ? 'Your new password was successfully set.'
+                  : 'Your account is fully set up! Next time, go straight to Log In to access your account.'}
               </Subtitle>
               <FilledButtonContainer
                 style={{ marginTop: 48 }}

--- a/screens/auth/PasswordResetScreen.js
+++ b/screens/auth/PasswordResetScreen.js
@@ -1,4 +1,5 @@
 import { FontAwesome5 } from '@expo/vector-icons';
+import { StackActions } from '@react-navigation/native';
 import { FirebaseRecaptchaVerifierModal } from 'expo-firebase-recaptcha';
 import * as firebase from 'firebase';
 import PropTypes from 'prop-types';
@@ -93,6 +94,7 @@ export default class PasswordResetScreen extends React.Component {
       values: { ...prevState.values, [inputField]: text },
       confirmed:
         // Compare with new verifyPassword value
+        !prevState.errors[inputFields.NEWPASSWORD] &&
         inputField === inputFields.VERIFYPASSWORD
           ? prevState.verified &&
             prevState.values[inputFields.NEWPASSWORD] === text &&
@@ -281,8 +283,30 @@ export default class PasswordResetScreen extends React.Component {
             />
           )}
 
-          <BackButton onPress={() => this.props.navigation.goBack()}>
-            <FontAwesome5 name="arrow-left" solid size={24} />
+          <BackButton
+            onPress={() => {
+              if (this.state.verified) {
+                Alert.alert(
+                  'Are you sure you want to go back? You will have to verify your phone number again.',
+                  '',
+                  [
+                    {
+                      text: 'Go back',
+                      onPress: () => this.props.navigation.goBack(),
+                    },
+                    {
+                      text: 'Cancel',
+                      style: 'cancel',
+                    },
+                  ]
+                );
+              } else {
+                this.props.navigation.goBack();
+              }
+            }}>
+            {!this.state.success && (
+              <FontAwesome5 name="arrow-left" solid size={24} />
+            )}
           </BackButton>
           {this.state.verified && !this.state.success && (
             <View>
@@ -381,13 +405,28 @@ export default class PasswordResetScreen extends React.Component {
               <Subtitle style={{ marginTop: 32 }}>
                 {this.state.forgot
                   ? 'Your new password was successfully set.'
-                  : 'Your account is fully set up! Next time, go straight to Log In to access your account.'}
+                  : 'Your account is fully set up! Next time, you can go straight to Log In to access your account.'}
               </Subtitle>
               <FilledButtonContainer
                 style={{ marginTop: 48 }}
                 color={Colors.primaryGreen}
                 width="100%"
-                onPress={() => this.props.navigation.navigate('LogIn')}>
+                onPress={() => {
+                  if (this.state.forgot) {
+                    this.props.navigation.navigate('Auth', {
+                      screen: 'LogIn',
+                    });
+                  } else {
+                    this.props.navigation.dispatch(
+                      StackActions.replace('LogIn')
+                    );
+                  }
+                  this.setState({
+                    success: false,
+                    verified: false,
+                    forgot: true,
+                  });
+                }}>
                 <ButtonLabel color={Colors.lightText}>Go to Log In</ButtonLabel>
               </FilledButtonContainer>
             </View>

--- a/screens/auth/PasswordResetScreen.js
+++ b/screens/auth/PasswordResetScreen.js
@@ -324,9 +324,7 @@ export default class PasswordResetScreen extends React.Component {
                 width="100%"
                 onPress={() => this.resetPassword()}
                 disabled={!this.state.confirmed}>
-                <ButtonLabel color={Colors.lightText}>
-                  Reset Password
-                </ButtonLabel>
+                <ButtonLabel color={Colors.lightText}>Set Password</ButtonLabel>
               </FilledButtonContainer>
             </View>
           )}
@@ -339,11 +337,11 @@ export default class PasswordResetScreen extends React.Component {
               <Subtitle style={{ marginTop: 32 }}>
                 {this.state.forgot
                   ? 'Enter the phone number connected to your account to reset your password.'
-                  : 'If you registered in store, enter your phone number to set a password for your account.'}
+                  : 'Enter the phone number you used to register in person to finish setting up your account.'}
               </Subtitle>
               <Caption style={{ marginTop: 8 }} color={Colors.secondaryText}>
-                You will recieve a text containing a 6-digit code to verify your
-                phone number. Msg & data rates may apply.
+                You will recieve a text containing a 6-digit verification code.
+                Msg & data rates may apply.
               </Caption>
               <FormContainer>
                 <AuthTextField

--- a/screens/auth/PasswordResetScreen.js
+++ b/screens/auth/PasswordResetScreen.js
@@ -57,6 +57,7 @@ export default class PasswordResetScreen extends React.Component {
         [inputFields.PHONENUM]: '',
         [inputFields.NEWPASSWORD]: '',
         [inputFields.VERIFYPASSWORD]: '',
+        submit: '',
       },
     };
   }
@@ -88,7 +89,7 @@ export default class PasswordResetScreen extends React.Component {
         console.log('Not reached');
     }
     this.setState((prevState) => ({
-      errors: { ...prevState.errors, [inputField]: errorMsg },
+      errors: { ...prevState.errors, [inputField]: errorMsg, submit: '' },
       values: { ...prevState.values, [inputField]: text },
       confirmed:
         // Compare with new verifyPassword value
@@ -158,7 +159,12 @@ export default class PasswordResetScreen extends React.Component {
       this.setState({ verificationId });
       this.setModalVisible(true);
     } catch (err) {
-      this.setModalVisible(true);
+      this.setState({
+        errors: {
+          submit: `Error: You must complete the verification pop-up. Make sure your phone number is valid and try again.`,
+        },
+      });
+      this.setModalVisible(false);
       console.log(err);
       logErrorToSentry({
         screen: 'PasswordResetScreen',
@@ -252,7 +258,9 @@ export default class PasswordResetScreen extends React.Component {
   };
 
   render() {
-    const validNumber = !this.state.errors[inputFields.PHONENUM];
+    const { errors, values } = this.state;
+    const validNumber = !errors[inputFields.PHONENUM];
+
     return (
       <AuthScreenContainer>
         <AuthScrollContainer
@@ -265,7 +273,7 @@ export default class PasswordResetScreen extends React.Component {
           />
           {this.state.modalVisible && (
             <VerificationScreen
-              number={this.state.values[inputFields.PHONENUM]}
+              number={values[inputFields.PHONENUM]}
               visible={this.state.modalVisible}
               verifyCode={this.verifyCode}
               resend={this.openRecaptcha}
@@ -284,7 +292,7 @@ export default class PasswordResetScreen extends React.Component {
               <FormContainer>
                 <AuthTextField
                   fieldType="New Password"
-                  value={this.state.values[inputFields.NEWPASSWORD]}
+                  value={values[inputFields.NEWPASSWORD]}
                   onBlurCallback={(value) => {
                     this.updateError(value, inputFields.NEWPASSWORD);
                     this.scrollView.scrollToEnd({ animated: true });
@@ -292,18 +300,18 @@ export default class PasswordResetScreen extends React.Component {
                   changeTextCallback={(text) =>
                     this.onTextChange(text, inputFields.NEWPASSWORD)
                   }
-                  error={this.state.errors[inputFields.NEWPASSWORD]}
+                  error={errors[inputFields.NEWPASSWORD]}
                 />
                 <AuthTextField
                   fieldType="Re-enter New Password"
-                  value={this.state.values[inputFields.VERIFYPASSWORD]}
+                  value={values[inputFields.VERIFYPASSWORD]}
                   onBlurCallback={(value) =>
                     this.updateError(value, inputFields.VERIFYPASSWORD)
                   }
                   changeTextCallback={(text) =>
                     this.onTextChange(text, inputFields.VERIFYPASSWORD)
                   }
-                  error={this.state.errors[inputFields.VERIFYPASSWORD]}
+                  error={errors[inputFields.VERIFYPASSWORD]}
                 />
               </FormContainer>
               <FilledButtonContainer
@@ -340,7 +348,7 @@ export default class PasswordResetScreen extends React.Component {
               <FormContainer>
                 <AuthTextField
                   fieldType="Phone Number"
-                  value={this.state.values[inputFields.PHONENUM]}
+                  value={values[inputFields.PHONENUM]}
                   onBlurCallback={(value) =>
                     this.updateError(value, inputFields.PHONENUM)
                   }
@@ -348,8 +356,13 @@ export default class PasswordResetScreen extends React.Component {
                     this.scrollView.scrollToEnd({ animated: true });
                     this.onTextChange(text, inputFields.PHONENUM);
                   }}
-                  error={this.state.errors[inputFields.PHONENUM]}
+                  error={errors[inputFields.PHONENUM]}
                 />
+                <Caption
+                  style={{ alignSelf: 'center', fontSize: 14 }}
+                  color={Colors.error}>
+                  {errors.submit}
+                </Caption>
               </FormContainer>
               <FilledButtonContainer
                 style={{ marginVertical: 24 }}

--- a/screens/auth/SignUpScreen.js
+++ b/screens/auth/SignUpScreen.js
@@ -1,4 +1,5 @@
 import { FontAwesome5 } from '@expo/vector-icons';
+import { StackActions } from '@react-navigation/native';
 import { Notifications } from 'expo';
 import Constants from 'expo-constants';
 import * as Analytics from 'expo-firebase-analytics';
@@ -12,9 +13,12 @@ import * as Sentry from 'sentry-expo';
 import AuthTextField from '../../components/AuthTextField';
 import {
   BigTitle,
+  Body,
+  ButtonContainer,
   ButtonLabel,
   Caption,
   FilledButtonContainer,
+  Subtitle,
 } from '../../components/BaseComponents';
 import Colors from '../../constants/Colors';
 import RecordIds from '../../constants/RecordIds';
@@ -39,6 +43,7 @@ import {
   BackButton,
   FormContainer,
 } from '../../styled/auth';
+import { RowContainer } from '../../styled/shared';
 import validate from './validation';
 import VerificationScreen from './VerificationScreen';
 
@@ -200,6 +205,30 @@ export default class SignUpScreen extends React.Component {
       if (duplicateCustomers.length !== 0) {
         console.log('Duplicate customer');
         const errorMsg = 'Phone number already in use';
+        if (
+          duplicateCustomers.length === 1 &&
+          !duplicateCustomers[0].password
+        ) {
+          Alert.alert(
+            'Phone number registered without a password',
+            `${
+              this.state.values[inputFields.PHONENUM]
+            } does not have a password yet. Set a password to finish setting up your account.`,
+            [
+              {
+                text: 'Set a password',
+                onPress: () =>
+                  this.props.navigation.navigate('Reset', {
+                    forgot: false,
+                  }),
+              },
+              {
+                text: 'Cancel',
+                style: 'cancel',
+              },
+            ]
+          );
+        }
         logAuthErrorToSentry({
           screen: 'SignUpScreen',
           action: 'handleSubmit',
@@ -385,10 +414,21 @@ export default class SignUpScreen extends React.Component {
             ref={this.state.recaptchaVerifier}
             firebaseConfig={firebaseConfig}
           />
-          <BackButton onPress={() => this.props.navigation.goBack(null)}>
+          <BackButton onPress={() => this.props.navigation.goBack()}>
             <FontAwesome5 name="arrow-left" solid size={24} />
           </BackButton>
           <BigTitle>Sign Up</BigTitle>
+          <Subtitle style={{ marginTop: 32 }}>
+            {'If you registered in person with your phone number, '}
+            <Subtitle
+              color={Colors.primaryGreen}
+              onPress={() =>
+                this.props.navigation.navigate('Reset', { forgot: false })
+              }>
+              click here to set a password
+            </Subtitle>
+            {' to finish setting up your account.'}
+          </Subtitle>
           <FormContainer>
             <AuthTextField
               fieldType="Name"
@@ -434,7 +474,7 @@ export default class SignUpScreen extends React.Component {
             </Caption>
           </FormContainer>
           <FilledButtonContainer
-            style={{ marginVertical: 24, alignSelf: 'flex-end' }}
+            style={{ marginTop: 24, marginBottom: 12, alignSelf: 'flex-end' }}
             color={
               !signUpPermission ? Colors.lightestGreen : Colors.primaryGreen
             }
@@ -443,6 +483,21 @@ export default class SignUpScreen extends React.Component {
             disabled={!signUpPermission}>
             <ButtonLabel color={Colors.lightText}>Continue</ButtonLabel>
           </FilledButtonContainer>
+
+          <RowContainer
+            style={{
+              justifyContent: 'center',
+            }}>
+            <Body>Already have an account? </Body>
+            <ButtonContainer
+              onPress={() =>
+                this.props.navigation.dispatch(StackActions.replace('LogIn'))
+              }>
+              <ButtonLabel noCaps color={Colors.primaryGreen}>
+                Log In
+              </ButtonLabel>
+            </ButtonContainer>
+          </RowContainer>
           {env === 'dev' && (
             <Button
               title="Testing Bypass"

--- a/screens/auth/SignUpScreen.js
+++ b/screens/auth/SignUpScreen.js
@@ -13,6 +13,7 @@ import AuthTextField from '../../components/AuthTextField';
 import {
   BigTitle,
   ButtonLabel,
+  Caption,
   FilledButtonContainer,
 } from '../../components/BaseComponents';
 import Colors from '../../constants/Colors';
@@ -60,6 +61,7 @@ export default class SignUpScreen extends React.Component {
         [inputFields.NAME]: '',
         [inputFields.PHONENUM]: '',
         [inputFields.PASSWORD]: '',
+        submit: '',
       },
       token: '',
     };
@@ -197,7 +199,7 @@ export default class SignUpScreen extends React.Component {
       );
       if (duplicateCustomers.length !== 0) {
         console.log('Duplicate customer');
-        const errorMsg = 'Phone number already in use.';
+        const errorMsg = 'Phone number already in use';
         logAuthErrorToSentry({
           screen: 'SignUpScreen',
           action: 'handleSubmit',
@@ -230,6 +232,9 @@ export default class SignUpScreen extends React.Component {
   };
 
   openRecaptcha = async () => {
+    // const number = '+1'.concat(
+    //   this.state.values[inputFields.PHONENUM].replace(/\D/g, '')
+    // );
     const number = '+1'.concat(this.state.values[inputFields.PHONENUM]);
     const phoneProvider = new firebase.auth.PhoneAuthProvider();
     try {
@@ -241,7 +246,12 @@ export default class SignUpScreen extends React.Component {
       this.setState({ verificationId });
       this.setModalVisible(true);
     } catch (err) {
-      this.setModalVisible(true);
+      this.setState({
+        errors: {
+          submit: `Error: You must complete the verification pop-up. Make sure your phone number is valid and try again.`,
+        },
+      });
+      this.setModalVisible(false);
       console.log(err);
       logErrorToSentry({
         screen: 'SignUpScreen',
@@ -302,7 +312,7 @@ export default class SignUpScreen extends React.Component {
     }
 
     this.setState((prevState) => ({
-      errors: { ...prevState.errors, [inputField]: errorMsg },
+      errors: { ...prevState.errors, [inputField]: errorMsg, submit: '' },
       values: { ...prevState.values, [inputField]: text },
     }));
 
@@ -363,7 +373,7 @@ export default class SignUpScreen extends React.Component {
           }}>
           {this.state.modalVisible && (
             <VerificationScreen
-              number={this.state.values[inputFields.PHONENUM]}
+              number={values[inputFields.PHONENUM]}
               visible={this.state.modalVisible}
               verifyCode={this.verifyCode}
               resend={this.openRecaptcha}
@@ -382,7 +392,7 @@ export default class SignUpScreen extends React.Component {
           <FormContainer>
             <AuthTextField
               fieldType="Name"
-              value={this.state.values[inputFields.NAME]}
+              value={values[inputFields.NAME]}
               onBlurCallback={(value) => {
                 this.updateError(value, inputFields.NAME);
                 this.scrollView.scrollToEnd({ animated: true });
@@ -390,12 +400,12 @@ export default class SignUpScreen extends React.Component {
               changeTextCallback={async (text) =>
                 this.onTextChange(text, inputFields.NAME)
               }
-              error={this.state.errors[inputFields.NAME]}
+              error={errors[inputFields.NAME]}
             />
 
             <AuthTextField
               fieldType="Phone Number"
-              value={this.state.values[inputFields.PHONENUM]}
+              value={values[inputFields.PHONENUM]}
               onBlurCallback={(value) => {
                 this.updateError(value, inputFields.PHONENUM);
                 this.scrollView.scrollToEnd({ animated: true });
@@ -403,20 +413,25 @@ export default class SignUpScreen extends React.Component {
               changeTextCallback={(text) =>
                 this.onTextChange(text, inputFields.PHONENUM)
               }
-              error={this.state.errors[inputFields.PHONENUM]}
+              error={errors[inputFields.PHONENUM]}
             />
 
             <AuthTextField
               fieldType="Password"
-              value={this.state.values[inputFields.PASSWORD]}
+              value={values[inputFields.PASSWORD]}
               onBlurCallback={(value) =>
                 this.updateError(value, inputFields.PASSWORD)
               }
               changeTextCallback={(text) =>
                 this.onTextChange(text, inputFields.PASSWORD)
               }
-              error={this.state.errors[inputFields.PASSWORD]}
+              error={errors[inputFields.PASSWORD]}
             />
+            <Caption
+              style={{ alignSelf: 'center', fontSize: 14 }}
+              color={Colors.error}>
+              {errors.submit}
+            </Caption>
           </FormContainer>
           <FilledButtonContainer
             style={{ marginVertical: 24, alignSelf: 'flex-end' }}
@@ -426,7 +441,7 @@ export default class SignUpScreen extends React.Component {
             width="100%"
             onPress={() => this.handleSubmit()}
             disabled={!signUpPermission}>
-            <ButtonLabel color={Colors.lightText}>Sign Up</ButtonLabel>
+            <ButtonLabel color={Colors.lightText}>Continue</ButtonLabel>
           </FilledButtonContainer>
           {env === 'dev' && (
             <Button

--- a/screens/auth/SignUpScreen.js
+++ b/screens/auth/SignUpScreen.js
@@ -488,7 +488,7 @@ export default class SignUpScreen extends React.Component {
             style={{
               justifyContent: 'center',
             }}>
-            <Body>Already have an account? </Body>
+            <Body>{`Already have an account? `}</Body>
             <ButtonContainer
               onPress={() =>
                 this.props.navigation.dispatch(StackActions.replace('LogIn'))

--- a/screens/auth/WelcomeScreen.js
+++ b/screens/auth/WelcomeScreen.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { AsyncStorage, Image, View } from 'react-native';
 import {
+  Body,
   ButtonContainer,
   ButtonLabel,
   FilledButtonContainer,
@@ -9,6 +10,7 @@ import {
 import Colors from '../../constants/Colors';
 import RecordIds from '../../constants/RecordIds';
 import { WelcomeContainer } from '../../styled/auth';
+import { RowContainer } from '../../styled/shared';
 
 export default class WelcomeScreen extends React.Component {
   guestLogin = async () => {
@@ -57,15 +59,6 @@ export default class WelcomeScreen extends React.Component {
             onPress={() => this.navigateLogIn()}>
             <ButtonLabel color="white">Log In</ButtonLabel>
           </FilledButtonContainer>
-          <FilledButtonContainer
-            style={{ marginTop: 12 }}
-            color={Colors.lighterGreen}
-            width="100%"
-            onPress={() =>
-              this.props.navigation.navigate('Reset', { forgot: false })
-            }>
-            <ButtonLabel color="white">Registered in-store</ButtonLabel>
-          </FilledButtonContainer>
           <ButtonContainer
             style={{ marginTop: 4, padding: 12 }}
             onPress={async () => this.guestLogin()}>
@@ -73,6 +66,22 @@ export default class WelcomeScreen extends React.Component {
               Continue without an account
             </ButtonLabel>
           </ButtonContainer>
+          <RowContainer
+            style={{
+              marginTop: 14,
+              padding: 12,
+              justifyContent: 'center',
+            }}>
+            <Body>Registered in store? </Body>
+            <ButtonContainer
+              onPress={() =>
+                this.props.navigation.navigate('Reset', { forgot: false })
+              }>
+              <ButtonLabel noCaps color={Colors.primaryGreen}>
+                Set a password
+              </ButtonLabel>
+            </ButtonContainer>
+          </RowContainer>
         </View>
       </WelcomeContainer>
     );

--- a/screens/auth/WelcomeScreen.js
+++ b/screens/auth/WelcomeScreen.js
@@ -63,7 +63,7 @@ export default class WelcomeScreen extends React.Component {
             style={{ marginTop: 4, padding: 12 }}
             onPress={async () => this.guestLogin()}>
             <ButtonLabel noCaps color={Colors.primaryGreen}>
-              Continue without an account
+              Continue as guest
             </ButtonLabel>
           </ButtonContainer>
           <RowContainer
@@ -72,7 +72,7 @@ export default class WelcomeScreen extends React.Component {
               padding: 12,
               justifyContent: 'center',
             }}>
-            <Body>Registered in store? </Body>
+            <Body>Registered in person? </Body>
             <ButtonContainer
               onPress={() =>
                 this.props.navigation.navigate('Reset', { forgot: false })

--- a/screens/auth/WelcomeScreen.js
+++ b/screens/auth/WelcomeScreen.js
@@ -57,6 +57,15 @@ export default class WelcomeScreen extends React.Component {
             onPress={() => this.navigateLogIn()}>
             <ButtonLabel color="white">Log In</ButtonLabel>
           </FilledButtonContainer>
+          <FilledButtonContainer
+            style={{ marginTop: 12 }}
+            color={Colors.lighterGreen}
+            width="100%"
+            onPress={() =>
+              this.props.navigation.navigate('Reset', { forgot: false })
+            }>
+            <ButtonLabel color="white">Registered in-store</ButtonLabel>
+          </FilledButtonContainer>
           <ButtonContainer
             style={{ marginTop: 4, padding: 12 }}
             onPress={async () => this.guestLogin()}>

--- a/screens/auth/validation.js
+++ b/screens/auth/validation.js
@@ -17,7 +17,7 @@ const validation = {
       message: '^Phone number cannot be blank',
     },
     length: {
-      is: 10,
+      is: 14,
       message: '^Must be a valid phone number',
     },
     // To check for only numbers in the future

--- a/screens/resources/ResourcesScreen.js
+++ b/screens/resources/ResourcesScreen.js
@@ -69,8 +69,8 @@ export default class ResourcesScreen extends React.Component {
       <View>
         <NavHeaderContainer>
           <NavButtonContainer
-            onPress={() => this.props.navigation.goBack(null)}>
-            <FontAwesome5 name="arrow-left" solid size={24} />
+            onPress={() => this.props.navigation.toggleDrawer()}>
+            <FontAwesome5 name="bars" solid size={24} />
           </NavButtonContainer>
           <NavTitle>Resources</NavTitle>
         </NavHeaderContainer>

--- a/screens/rewards/RewardsScreen.js
+++ b/screens/rewards/RewardsScreen.js
@@ -74,7 +74,7 @@ export default class RewardsScreen extends React.Component {
   }
 
   _logout = async () => {
-    this.props.navigation.goBack();
+    this.props.navigation.navigate('Stores');
     await AsyncStorage.clear();
     Sentry.configureScope((scope) => scope.clear());
     this.props.navigation.navigate('Auth', { screen: 'SignUp' });

--- a/screens/settings/PhoneNumberChangeScreen.js
+++ b/screens/settings/PhoneNumberChangeScreen.js
@@ -258,8 +258,8 @@ export default class PhoneNumberChangeScreen extends React.Component {
             </BackButton>
             <BigTitle>Change Phone Number</BigTitle>
             <Caption style={{ marginTop: 8 }} color={Colors.secondaryText}>
-              You will recieve a text containing a 6-digit code to verify this
-              phone number. Msg & data rates may apply.
+              You will recieve a text containing a 6-digit verification code.
+              Msg & data rates may apply.
             </Caption>
             <FormContainer>
               <AuthTextField
@@ -285,7 +285,7 @@ export default class PhoneNumberChangeScreen extends React.Component {
               width="100%"
               onPress={() => this.openRecaptcha()}
               disabled={!permission}>
-              <ButtonLabel color={Colors.lightText}>Change Number</ButtonLabel>
+              <ButtonLabel color={Colors.lightText}>Verify Number</ButtonLabel>
             </FilledButtonContainer>
           </View>
         )}

--- a/screens/settings/PhoneNumberChangeScreen.js
+++ b/screens/settings/PhoneNumberChangeScreen.js
@@ -45,6 +45,7 @@ export default class PhoneNumberChangeScreen extends React.Component {
       },
       errors: {
         [inputFields.PHONENUM]: '',
+        submit: '',
       },
     };
   }
@@ -82,7 +83,7 @@ export default class PhoneNumberChangeScreen extends React.Component {
         console.log('Not reached');
     }
     this.setState((prevState) => ({
-      errors: { ...prevState.errors, [inputField]: errorMsg },
+      errors: { ...prevState.errors, [inputField]: errorMsg, submit: '' },
       values: { ...prevState.values, [inputField]: text },
     }));
 
@@ -130,7 +131,7 @@ export default class PhoneNumberChangeScreen extends React.Component {
       );
       if (duplicateCustomers.length !== 0) {
         console.log('Duplicate customer');
-        const errorMsg = 'Phone number already in use.';
+        const errorMsg = 'Phone number already in use';
         logAuthErrorToSentry({
           screen: 'PhoneNumberChangeScreen',
           action: 'updatePhoneNumber',
@@ -171,7 +172,12 @@ export default class PhoneNumberChangeScreen extends React.Component {
       this.setState({ verificationId });
       this.setModalVisible(true);
     } catch (err) {
-      this.setModalVisible(true);
+      this.setState({
+        errors: {
+          submit: `Error: You must complete the verification pop-up. Make sure your phone number is valid and try again.`,
+        },
+      });
+      this.setModalVisible(false);
       console.log(err);
       logErrorToSentry({
         screen: 'PhoneNumberChangeScreen',
@@ -267,6 +273,11 @@ export default class PhoneNumberChangeScreen extends React.Component {
                 }
                 error={this.state.errors[inputFields.PHONENUM]}
               />
+              <Caption
+                style={{ alignSelf: 'center', fontSize: 14 }}
+                color={Colors.error}>
+                {errors.submit}
+              </Caption>
             </FormContainer>
             <FilledButtonContainer
               style={{ marginTop: 48 }}

--- a/styled/resources.js
+++ b/styled/resources.js
@@ -19,19 +19,18 @@ export const ContentContainer = styled.View`
 export const IconContainer = styled.View`
   align-items: center;
   justify-content: center;
-  margin: 12px;
+  margin: 0px 4px 0px 8px;
 `;
 
 export const CategoryCard = styled.View`
   background-color: ${Colors.lightestGray};
-  padding: 10px 18px;
+  padding: 10px 24px;
   flex-direction: row;
   flex: 1;
 `;
 
 export const CategoryHeadingContainer = styled.View`
   flex-direction: row;
-  padding-left: 12px;
   align-content: center;
   align-items: center;
   justify-content: center;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11214,6 +11214,14 @@ libphonenumber-js@^1.7.28:
     minimist "^1.2.5"
     xml2js "^0.4.17"
 
+libphonenumber-js@^1.7.52:
+  version "1.7.52"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.7.52.tgz#a30dc8ec4dfa2ce651a6abf76c6b141b244b1aa3"
+  integrity sha512-NnJbWGRWIAQwz3UOXJoka92FJqmr/VvGIHienUMnBf7QNSCYF2WhvknEgpQIhL8VLZp/rJg3m3czOHRAmyYMLg==
+  dependencies:
+    minimist "^1.2.5"
+    xml2js "^0.4.17"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15023,6 +15023,11 @@ react-modal@^3.8.1:
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 
+react-native-alert-async@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-native-alert-async/-/react-native-alert-async-1.0.5.tgz#f67e3d1f6c877cce8e8cd74cef3d596713f0fdb4"
+  integrity sha512-HeG0zdjtlANl8KkF9AhqgkaEooXip44Fb01dmCnYSYMm6PoRdcV4aIy6l/yAOQmArrl8LTP58APSiuZXBMCbwQ==
+
 react-native-animatable@^1.3.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
- Customers can first register for Rewards in-store by giving store clerks their name and phone number (in https://github.com/calblueprint/dccentralkitchen-clerks/pull/59). They can then download the customer app and access their account by setting a password.
  - The flow is very similar to resetting a password:
    1. Enter phone number
    2. Verify phone number
    3. Set password
  - Since the flow is so similar, the functionality also lives in `PasswordResetScreen`. The `forgot` boolean that indicates whether the screen is for 'Forgot password' or 'Registered in-store', which modifies some copy and checks that the phone number does not already have a password set
- Added 'as you type' formatting for phone number inputs from `libphonenumber-js`

- Updated hamburger menu designs
- Added clarifying copy and alerts to the auth flow
- Cleaned up some navigation + logout issues

## Relevant Links

### Online sources

https://github.com/catamphetamine/libphonenumber-js

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
https://github.com/calblueprint/dccentralkitchen-clerks/pull/59

## Next steps
Look into issues with closing the captcha in the middle of the process. https://github.com/calblueprint/dccentralkitchen/issues/144

### Screenshots
https://www.loom.com/share/7b0faa9f7ad947dd94aa03a654e6a564
https://www.loom.com/share/aa603f71d5a04ae7b17d80a265d14ea3
