### PR TITLE
Update Resources and PointsHistory to SectionList, update Transaction card for survey completion

### DIFF
--- a/components/resources/CategoryBar.js
+++ b/components/resources/CategoryBar.js
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Colors from '../../constants/Colors';
 import { CategoryCard, CategoryHeadingContainer } from '../../styled/resources';
-import { Title } from '../BaseComponents';
+import { Subtitle, Title } from '../BaseComponents';
 import CircleIcon from '../CircleIcon';
 
-function CategoryBar({ icon, title }) {
+function CategoryBar({ icon, title, mini }) {
   return (
     <CategoryCard>
       {icon !== '' && (
@@ -16,7 +16,7 @@ function CategoryBar({ icon, title }) {
         />
       )}
       <CategoryHeadingContainer style={icon !== '' && { marginLeft: 12 }}>
-        <Title>{title}</Title>
+        {mini ? <Subtitle>{title}</Subtitle> : <Title>{title}</Title>}
       </CategoryHeadingContainer>
     </CategoryCard>
   );
@@ -25,10 +25,12 @@ function CategoryBar({ icon, title }) {
 CategoryBar.propTypes = {
   icon: PropTypes.string,
   title: PropTypes.string.isRequired,
+  mini: PropTypes.bool,
 };
 
 CategoryBar.defaultProps = {
   icon: '',
+  mini: false,
 };
 
 export default CategoryBar;

--- a/components/resources/ResourceCard.js
+++ b/components/resources/ResourceCard.js
@@ -11,20 +11,20 @@ import {
 } from '../../styled/resources';
 import { Body, ButtonContainer, Subtitle } from '../BaseComponents';
 
-function cardPressed(resource) {
+function cardPressed(title, category, url) {
   Analytics.logEvent('open_resource_link', {
-    resource_name: resource.title,
-    resource_category: resource.category.toString(),
+    resource_name: title,
+    resource_category: category.toString(),
   });
-  WebBrowser.openBrowserAsync(resource.url);
+  WebBrowser.openBrowserAsync(url);
 }
-function ResourceCard({ resourceCard }) {
+function ResourceCard({ title, description, category, url }) {
   return (
-    <ButtonContainer onPress={() => cardPressed(resourceCard)}>
+    <ButtonContainer onPress={() => cardPressed(title, category, url)}>
       <ResourceItemCard>
         <ContentContainer>
-          <Subtitle>{resourceCard.title}</Subtitle>
-          <Body color={Colors.secondaryText}>{resourceCard.description}</Body>
+          <Subtitle>{title}</Subtitle>
+          <Body color={Colors.secondaryText}>{description}</Body>
         </ContentContainer>
         <IconContainer>
           <FontAwesome5
@@ -39,7 +39,15 @@ function ResourceCard({ resourceCard }) {
 }
 
 ResourceCard.propTypes = {
-  resourceCard: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  category: PropTypes.array,
+  url: PropTypes.string.isRequired,
+};
+
+ResourceCard.defaultProps = {
+  description: '',
+  category: [],
 };
 
 export default ResourceCard;

--- a/components/rewards/PointsHistory.js
+++ b/components/rewards/PointsHistory.js
@@ -31,6 +31,7 @@ function PointsHistory({ transactions }) {
             totalSale={item.totalSale}
             rewardsUnlocked={item.rewardsUnlocked}
             rewardsApplied={item.rewardsApplied}
+            storeId={item.storeId}
           />
         )}
         keyExtractor={(item) => item.id}

--- a/components/rewards/PointsHistory.js
+++ b/components/rewards/PointsHistory.js
@@ -1,9 +1,12 @@
 import { FontAwesome5 } from '@expo/vector-icons';
+import _ from 'lodash';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { FlatList, View } from 'react-native';
+import { SectionList, View } from 'react-native';
 import Colors from '../../constants/Colors';
-import { Body, Overline } from '../BaseComponents';
+import { Body } from '../BaseComponents';
+import CategoryBar from '../resources/CategoryBar';
 import Transaction from './Transaction';
 
 /**
@@ -11,16 +14,29 @@ import Transaction from './Transaction';
  * */
 
 function PointsHistory({ transactions }) {
+  const groupedTransactions = _.groupBy(transactions, (transaction) =>
+    moment(transaction.date)
+      .startOf('month')
+      .format('MMMM YYYY')
+  );
+  const sections = [];
+  Object.entries(groupedTransactions).forEach(([month, tactions]) => {
+    sections.push({
+      month,
+      data: tactions,
+    });
+  });
+
   return (
     <View>
-      <FlatList
-        ListHeaderComponent={
-          <Overline style={{ marginTop: 24, marginLeft: 16, marginBottom: 12 }}>
-            Recent Transactions
-          </Overline>
-        }
+      <SectionList
+        sections={sections}
         initialNumToRender={10}
-        data={transactions}
+        renderSectionHeader={({ section }) =>
+          section.data.length > 0 ? (
+            <CategoryBar mini title={section.month} />
+          ) : null
+        }
         renderItem={({ item }) => (
           <Transaction
             key={item.id}

--- a/components/rewards/RewardsHome.js
+++ b/components/rewards/RewardsHome.js
@@ -1,16 +1,13 @@
 import { FontAwesome5 } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { FlatList, PixelRatio, ScrollView, View } from 'react-native';
+import { FlatList, PixelRatio, View } from 'react-native';
 import { ProgressBar } from 'react-native-paper';
 import Colors from '../../constants/Colors';
 import Window from '../../constants/Layout';
 import { rewardDollarValue, rewardPointValue } from '../../constants/Rewards';
 import { displayDollarValue } from '../../lib/common';
-import {
-  AvailableRewardsContainer,
-  RewardsProgressContainer,
-} from '../../styled/rewards';
+import { RewardsProgressContainer } from '../../styled/rewards';
 import { Body, Overline, Title } from '../BaseComponents';
 import ParticipatingStores from './ParticipatingStores';
 import RewardsCard from './RewardsCard';
@@ -31,70 +28,73 @@ function RewardsHome({ customer, participating }) {
   const rewardsAvailable = parseInt(customer.points, 10) / rewardPointValue;
   const pointsToNext = parseInt(customer.points, 10) % rewardPointValue;
   return (
-    <ScrollView style={{ marginLeft: 16, paddingRight: 16 }}>
-      <RewardsProgressContainer>
-        <Overline style={{ marginTop: 24, marginBottom: 12 }}>
-          Reward Progress
-        </Overline>
-        <Title style={{ marginBottom: 2 }}>
-          {`${pointsToNext || 0} / ${rewardPointValue}`}
-        </Title>
-        <ProgressBar
-          style={{
-            height: 20,
-            width: '100%',
-            borderRadius: 20,
-            marginBottom: 15,
-          }}
-          progress={pointsToNext / rewardPointValue}
-          color={Colors.primaryGreen}
-        />
-        <Body style={{ marginBottom: 28 }}>
-          {`Buy ${displayDollarValue(
-            (rewardPointValue - pointsToNext) / 100
-          )} of healthy food to earn ${rewardPointValue -
-            pointsToNext} points and unlock your next $${rewardDollarValue} reward`}
-        </Body>
-        <Overline style={{ marginBottom: 8 }}>
-          {`Available Rewards (${Math.floor(rewardsAvailable)})`}
-        </Overline>
-      </RewardsProgressContainer>
-      <AvailableRewardsContainer>
-        <FlatList
-          data={createList(Math.floor(rewardsAvailable))}
-          renderItem={() => <RewardsCard />}
-          keyExtractor={(item, index) => index.toString()}
-          numColumns={
-            Window.width > 370 && PixelRatio.getFontScale() < 1.2 ? 2 : 1
-          }
-          ListEmptyComponent={
-            <View
+    <View style={{ marginLeft: 16 }}>
+      <FlatList
+        style={{ paddingRight: 16 }}
+        data={createList(Math.floor(rewardsAvailable))}
+        renderItem={() => <RewardsCard />}
+        keyExtractor={(item, index) => index.toString()}
+        numColumns={
+          Window.width > 370 && PixelRatio.getFontScale() < 1.2 ? 2 : 1
+        }
+        // Rewards Progress section
+        ListHeaderComponent={
+          <RewardsProgressContainer>
+            <Overline style={{ marginTop: 24, marginBottom: 12 }}>
+              Reward Progress
+            </Overline>
+            <Title style={{ marginBottom: 2 }}>
+              {`${pointsToNext || 0} / ${rewardPointValue}`}
+            </Title>
+            <ProgressBar
               style={{
-                alignItems: 'center',
-                marginTop: 20,
-                paddingLeft: 32,
-                paddingRight: 32,
-              }}>
-              <FontAwesome5
-                name="star"
-                size={64}
-                solid
-                color={Colors.primaryGray}
-                style={{ marginBottom: 12 }}
-              />
-              <Body color={Colors.secondaryText}>No available rewards.</Body>
-              <Body
-                color={Colors.secondaryText}
-                style={{ textAlign: 'center' }}>
-                Buy healthy produce at participating stores to earn points and
-                unlock rewards!
-              </Body>
-            </View>
-          }
-        />
-      </AvailableRewardsContainer>
-      <ParticipatingStores participating={participating} guest={false} />
-    </ScrollView>
+                height: 20,
+                width: '100%',
+                borderRadius: 20,
+                marginBottom: 15,
+              }}
+              progress={pointsToNext / rewardPointValue}
+              color={Colors.primaryGreen}
+            />
+            <Body style={{ marginBottom: 28 }}>
+              {`Buy ${displayDollarValue(
+                (rewardPointValue - pointsToNext) / 100
+              )} of healthy food to earn ${rewardPointValue -
+                pointsToNext} points and unlock your next $${rewardDollarValue} reward`}
+            </Body>
+            <Overline style={{ marginBottom: 8 }}>
+              {`Available Rewards (${Math.floor(rewardsAvailable)})`}
+            </Overline>
+          </RewardsProgressContainer>
+        }
+        ListEmptyComponent={
+          <View
+            style={{
+              alignItems: 'center',
+              marginTop: 20,
+              paddingLeft: 32,
+              paddingRight: 32,
+            }}>
+            <FontAwesome5
+              name="star"
+              size={64}
+              solid
+              color={Colors.primaryGray}
+              style={{ marginBottom: 12 }}
+            />
+            <Body color={Colors.secondaryText}>No available rewards.</Body>
+            <Body color={Colors.secondaryText} style={{ textAlign: 'center' }}>
+              Buy healthy produce at participating stores to earn points and
+              unlock rewards!
+            </Body>
+          </View>
+        }
+        // Participating Stores section
+        ListFooterComponent={
+          <ParticipatingStores participating={participating} guest={false} />
+        }
+      />
+    </View>
   );
 }
 

--- a/components/rewards/Transaction.js
+++ b/components/rewards/Transaction.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { View } from 'react-native';
 import Colors from '../../constants/Colors';
+import RecordIds from '../../constants/RecordIds';
 import { rewardDollarValue, rewardPointValue } from '../../constants/Rewards';
 import { displayDollarValue } from '../../lib/common';
 import { ContentContainer, TransactionCard } from '../../styled/transaction';
@@ -20,6 +21,7 @@ function Transaction(props) {
     totalSale,
     rewardsUnlocked,
     rewardsApplied,
+    storeId,
   } = props;
   const options = {
     weekday: 'short',
@@ -62,7 +64,9 @@ function Transaction(props) {
           </Caption>
           <Subtitle>{`${pointsEarned} points earned`}</Subtitle>
           <Caption color={Colors.secondaryText}>
-            {`for ${displayDollarValue(totalSale || 0)} of healthy products`}
+            {storeId === RecordIds.surveyStoreId
+              ? `for completing a survey`
+              : `for ${displayDollarValue(totalSale || 0)} of healthy products`}
           </Caption>
         </ContentContainer>
       </TransactionCard>
@@ -94,6 +98,7 @@ Transaction.propTypes = {
   totalSale: PropTypes.number,
   rewardsUnlocked: PropTypes.number,
   rewardsApplied: PropTypes.number,
+  storeId: PropTypes.string.isRequired,
 };
 
 Transaction.defaultProps = {

--- a/constants/RecordIds.js
+++ b/constants/RecordIds.js
@@ -6,19 +6,21 @@ const RecordIds = {
   defaultStoreId: null,
 };
 
-// Default store is 'Dollar Plus Howard'
+// Default store is 'Stanton Supermarket'
 
 // IDs from DEV base
 if (env === 'dev') {
   RecordIds.testCustomerId = 'recimV9zs2StWB2Mj';
   RecordIds.guestCustomerId = 'recLKK7cZHboMPEB8';
   RecordIds.defaultStoreId = 'rec6C14onap95XOK8';
+  RecordIds.surveyStoreId = 'recfB0SrHB8b6a3Bb';
 
   // IDs from PROD base
 } else if (env === 'prod') {
   RecordIds.testCustomerId = 'recomWMtzSUQCcIvr';
   RecordIds.guestCustomerId = 'recxEGfvExP4Dv8nr';
   RecordIds.defaultStoreId = 'recwQ6SoM5pEj37xl';
+  RecordIds.surveyStoreId = 'recQa6jv9KGqobDAZ';
 }
 
 export default RecordIds;

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "global": "^4.4.0",
     "install": "^0.13.0",
     "libphonenumber-js": "^1.7.52",
+    "lodash": "^4.17.20",
+    "moment": "^2.29.1",
     "npm": "^6.14.6",
     "prop-types": "^15.0",
     "react": "16.11.0",

--- a/screens/resources/ResourcesScreen.js
+++ b/screens/resources/ResourcesScreen.js
@@ -85,7 +85,10 @@ export default class ResourcesScreen extends React.Component {
           renderItem={({ item }) => (
             <ResourceCard
               key={item.id}
-              resourceCard={item}
+              title={item.title}
+              description={item.description}
+              category={item.category}
+              url={item.url}
               navigation={this.props.navigation}
             />
           )}

--- a/screens/resources/ResourcesScreen.js
+++ b/screens/resources/ResourcesScreen.js
@@ -1,7 +1,7 @@
 import { FontAwesome5 } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ScrollView, View } from 'react-native';
+import { SectionList, View } from 'react-native';
 import {
   NavButtonContainer,
   NavHeaderContainer,
@@ -16,49 +16,49 @@ export default class ResourcesScreen extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      CrisisResponse: [],
-      FoodAccess: [],
-      HealthyEating: [],
-      Seniors: [],
-      SocialServices: [],
-      Miscellaneous: [],
+      sections: [],
     };
   }
 
   async componentDidMount() {
     try {
       const resources = await getAllResources();
-      const CrisisResponse = resources.filter((resource) =>
-        resource.category.includes('Crisis Response')
-      );
-      const FoodAccess = resources.filter((resource) =>
-        resource.category.includes('Food Access')
-      );
-      const HealthyEating = resources.filter((resource) =>
-        resource.category.includes('Healthy Cooking & Eating')
-      );
-      const Seniors = resources.filter((resource) =>
-        resource.category.includes('Seniors')
-      );
-      const SocialServices = resources.filter((resource) =>
-        resource.category.includes('Social Services')
-      );
+      const sections = [];
+
+      // Category titles and their FontAwesome5 Icons
+      const categories = {
+        'Crisis Response': 'exclamation-triangle',
+        'Food Access': 'utensils',
+        'Healthy Cooking & Eating': 'carrot',
+        Seniors: 'user',
+        'Social Services': 'hands-helping',
+      };
+
+      Object.entries(categories).forEach(([category, icon]) => {
+        sections.push({
+          category,
+          icon,
+          data: resources.filter(
+            (resource) =>
+              resource.category && resource.category.includes(category)
+          ),
+        });
+      });
+
+      // Resources without a matching category are considered Miscellaneous
       const Miscellaneous = resources.filter(
         (resource) =>
-          !resource.category.includes('Crisis Response') &&
-          !resource.category.includes('Food Access') &&
-          !resource.category.includes('Healthy Cooking & Eating') &&
-          !resource.category.includes('Seniors') &&
-          !resource.category.includes('Social Services')
+          !resource.category ||
+          (resource.category &&
+            !resource.category.some((element) => element in categories))
       );
-      this.setState({
-        CrisisResponse,
-        FoodAccess,
-        HealthyEating,
-        Seniors,
-        SocialServices,
-        Miscellaneous,
+      sections.push({
+        category: 'Miscellaneous',
+        icon: 'book-open',
+        data: Miscellaneous,
       });
+
+      this.setState({ sections });
     } catch (err) {
       console.error('[ResourcesScreen] Airtable: ', err);
       logErrorToSentry({
@@ -79,69 +79,23 @@ export default class ResourcesScreen extends React.Component {
           </NavButtonContainer>
           <NavTitle>Resources</NavTitle>
         </NavHeaderContainer>
-        <ScrollView>
-          {this.state.CrisisResponse.length > 0 && (
-            <CategoryBar icon="exclamation-triangle" title="Crisis Response" />
-          )}
-          {this.state.CrisisResponse.map((resource) => (
+        <SectionList
+          sections={this.state.sections}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
             <ResourceCard
-              key={resource.id}
-              resourceCard={resource}
+              key={item.id}
+              resourceCard={item}
               navigation={this.props.navigation}
             />
-          ))}
-          {this.state.FoodAccess.length > 0 && (
-            <CategoryBar icon="utensils" title="Food Access" />
           )}
-          {this.state.FoodAccess.map((resource) => (
-            <ResourceCard
-              key={resource.id}
-              resourceCard={resource}
-              navigation={this.props.navigation}
-            />
-          ))}
-          {this.state.HealthyEating.length > 0 && (
-            <CategoryBar icon="carrot" title="Healthy Cooking & Eating" />
-          )}
-          {this.state.HealthyEating.map((resource) => (
-            <ResourceCard
-              key={resource.id}
-              resourceCard={resource}
-              navigation={this.props.navigation}
-            />
-          ))}
-          {this.state.Seniors.length > 0 && (
-            <CategoryBar icon="user" title="Seniors" />
-          )}
-          {this.state.Seniors.map((resource) => (
-            <ResourceCard
-              key={resource.id}
-              resourceCard={resource}
-              navigation={this.props.navigation}
-            />
-          ))}
-          {this.state.SocialServices.length > 0 && (
-            <CategoryBar icon="hands-helping" title="Social Services" />
-          )}
-          {this.state.SocialServices.map((resource) => (
-            <ResourceCard
-              key={resource.id}
-              resourceCard={resource}
-              navigation={this.props.navigation}
-            />
-          ))}
-          {this.state.Miscellaneous.length > 0 && (
-            <CategoryBar icon="book-open" title="Miscellaneous" />
-          )}
-          {this.state.Miscellaneous.map((resource) => (
-            <ResourceCard
-              key={resource.id}
-              resourceCard={resource}
-              navigation={this.props.navigation}
-            />
-          ))}
-          <View style={{ paddingBottom: 150 }} />
-        </ScrollView>
+          renderSectionHeader={({ section }) =>
+            section.data.length > 0 ? (
+              <CategoryBar icon={section.icon} title={section.category} />
+            ) : null
+          }
+          ListFooterComponent={<View style={{ height: 200 }} />}
+        />
       </View>
     );
   }

--- a/styled/resources.js
+++ b/styled/resources.js
@@ -26,7 +26,6 @@ export const CategoryCard = styled.View`
   background-color: ${Colors.lightestGray};
   padding: 10px 24px;
   flex-direction: row;
-  flex: 1;
 `;
 
 export const CategoryHeadingContainer = styled.View`

--- a/styled/rewards.js
+++ b/styled/rewards.js
@@ -29,14 +29,6 @@ export const RewardsProgressContainer = styled.View`
   flex-direction: column;
 `;
 
-export const AvailableRewardsContainer = styled.View`
-  margin: 8px 0;
-  display: flex
-  width: 100%
-  flex-wrap: wrap;
-  justify-content: flex-start;
-`;
-
 export const styles = StyleSheet.create({
   tabView: {
     flex: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13125,7 +13125,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.10.6:
+moment@^2.10.6, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
- Added support for earning points by completing SurveyMonkey surveys (through Zapier integration): if points were earned from the store labeled 'SURVEY', the transaction card label will change to "....points earned for completing a survey".

**Refactoring + Cleanup**
- Converted ResourceScreen to a `SectionList`, which simplifies the code and makes it easier to add/update resource categories and icons.
- Converted Points History to a `SectionList` which adds month section headings to the list of transactions.
- Resolved the `VirtualizedLists should never be nested inside plain ScrollViews with the same orientation - use another VirtualizedList-backed container instead.` warning on RewardsScreen.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links

### Online sources
https://reactnative.dev/docs/sectionlist
https://stackoverflow.com/questions/58243680/react-native-another-virtualizedlist-backed-container

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

## Next steps

- [x]  Documentation on updating Resources has been updated.

### Screenshots
**New Points History with date section separators**
![IMG_AE7E3826F992-1](https://user-images.githubusercontent.com/21160510/103246912-10443f80-4933-11eb-9eae-5b712d084a4e.jpeg)
